### PR TITLE
Harden deployment workflows and clarify STIX MΛGIC env/integration contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ API_PORT=4000
 BOT_PORT=4100
 STICKER_ENGINE_PORT=4200
 TRIGGER_ENGINE_PORT=4300
+TRIGGER_ENGINE_URL=http://localhost:4300
 
 # Infrastructure dependencies (required by API/Bot/engines)
 POSTGRES_URL=postgres://stixmagic:stixmagic@localhost:5432/stixmagic

--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,8 @@ NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL=http://localhost:3000
 NEXT_PUBLIC_STIXMAGIC_API_BASE_URL=http://localhost:4000
 NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME=StixMagicBot
 NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL=http://localhost:3000/dashboard
-# Optional pipeline manifest URL; leave empty to use bundled sample data
-NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL=
+# Optional pipeline manifest URL; omit to use bundled sample data
+# NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL=https://example.com/stixmagic-manifest.json
 # Set true to force demo-mode seeded data in UI
 NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA=false
 

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,19 @@
+# ----------------------------------------------------------------------------
+# STIX MΛGIC environment template
+# Copy to .env for local development:
+#   cp .env.example .env
+# ----------------------------------------------------------------------------
+
 NODE_ENV=development
+
+# Local service ports
 WEB_PORT=3000
 API_PORT=4000
 BOT_PORT=4100
 STICKER_ENGINE_PORT=4200
 TRIGGER_ENGINE_PORT=4300
+
+# Infrastructure dependencies (required by API/Bot/engines)
 POSTGRES_URL=postgres://stixmagic:stixmagic@localhost:5432/stixmagic
 S3_ENDPOINT=http://localhost:9000
 S3_REGION=us-east-1
@@ -11,41 +21,54 @@ S3_BUCKET=sticker-assets
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 
-# Shared STIX MΛGIC Telegram surface configuration.
+# Shared STIX MΛGIC Telegram platform configuration (server side)
 STIXMAGIC_PUBLIC_WEB_URL=http://localhost:3000
 STIXMAGIC_API_BASE_URL=http://localhost:4000
 TELEGRAM_BOT_TOKEN=replace_me
 TELEGRAM_BOT_USERNAME=StixMagicBot
 TELEGRAM_MINI_APP_URL=http://localhost:3000/dashboard
 TELEGRAM_BOT_MODE=polling
+# Required when TELEGRAM_BOT_MODE=webhook
 # TELEGRAM_WEBHOOK_URL=https://api.example.com/telegram/webhook
+# TELEGRAM_WEBHOOK_SECRET=replace_me_with_long_random_secret
+# Maximum accepted age (seconds) for Telegram Mini App init-data signatures
+TELEGRAM_INIT_DATA_MAX_AGE_SECONDS=3600
 
-# Web build-time Telegram Mini App configuration.
+# Web build-time configuration (NEXT_PUBLIC_* variables are client-visible)
 NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL=http://localhost:3000
 NEXT_PUBLIC_STIXMAGIC_API_BASE_URL=http://localhost:4000
 NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME=StixMagicBot
 NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL=http://localhost:3000/dashboard
+# Optional pipeline manifest URL; leave empty to use bundled sample data
 NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL=
+# Set true to force demo-mode seeded data in UI
 NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA=false
 
-# ── Cloudflare Pages deployment ──────────────────────────────────────────────
-# Production:  https://stixmagic.com
-# Dev/Preview: https://preview.stixmagic.com
+# ----------------------------------------------------------------------------
+# CI/CD configuration notes (GitHub repository settings)
+# ----------------------------------------------------------------------------
+# Required secrets:
+#   VERCEL_TOKEN             (if Vercel workflows enabled)
+#   CLOUDFLARE_API_TOKEN     (if Cloudflare Pages workflows enabled)
+#   CLOUDFLARE_ACCOUNT_ID    (if Cloudflare Pages workflows enabled)
+#   PREVIEW_REPO_TOKEN       (if external preview Pages workflow enabled)
 #
-# Required GitHub secrets (Settings → Secrets → Actions):
-#   CLOUDFLARE_API_TOKEN   – Cloudflare API token with "Cloudflare Pages:Edit" permission
-#   CLOUDFLARE_ACCOUNT_ID  – Your Cloudflare account ID (Cloudflare dashboard sidebar)
+# Recommended repository variables:
+#   DEPLOY_PROVIDER          one of: vercel | cloudflare | github-pages | external-pages
+#   ENABLE_PROD_DEPLOY       true to allow production deploy jobs, else false
+#   ENABLE_PREVIEW_DEPLOY    true to allow preview/dev deploy jobs, else false
 #
-# Required GitHub repository variable (Settings → Variables → Actions):
-#   CF_PAGES_PROJECT_NAME  – Cloudflare Pages project name (default: stixmagic-web)
-#
-# Optional per-environment overrides – if not set, the defaults below are used:
-#   STIXMAGIC_API_BASE_URL          – API base URL (production, default: https://stixmagic.com)
-#   STIXMAGIC_PUBLIC_WEB_URL        – Public web URL (production, default: https://stixmagic.com)
-#   STIXMAGIC_MINI_APP_URL          – Mini app URL (production, default: https://stixmagic.com/dashboard)
-#   STIXMAGIC_MANIFEST_URL          – Pipeline manifest URL (production)
-#   STIXMAGIC_API_BASE_URL_DEV      – API base URL (dev, default: https://preview.stixmagic.com)
-#   STIXMAGIC_PUBLIC_WEB_URL_DEV    – Public web URL (dev, default: https://preview.stixmagic.com)
-#   STIXMAGIC_MINI_APP_URL_DEV      – Mini app URL (dev, default: https://preview.stixmagic.com/dashboard)
-#   STIXMAGIC_MANIFEST_URL_DEV      – Pipeline manifest URL (dev/preview)
-#   STIXMAGIC_BOT_USERNAME          – Telegram bot username
+# Shared deploy variables (provider-specific workflows consume these):
+#   STIXMAGIC_API_BASE_URL
+#   STIXMAGIC_PUBLIC_WEB_URL
+#   STIXMAGIC_MINI_APP_URL
+#   STIXMAGIC_MANIFEST_URL
+#   STIXMAGIC_BOT_USERNAME
+#   STIXMAGIC_API_BASE_URL_DEV
+#   STIXMAGIC_PUBLIC_WEB_URL_DEV
+#   STIXMAGIC_MINI_APP_URL_DEV
+#   STIXMAGIC_MANIFEST_URL_DEV
+#   CF_PAGES_PROJECT_NAME
+#   PAGES_CUSTOM_DOMAIN
+#   PAGES_PREVIEW_DOMAIN
+#   PREVIEW_PAGES_REPO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,6 +33,7 @@ jobs:
 
       - name: Install
         run: pnpm install --frozen-lockfile
+
 
       - name: Typecheck
         run: pnpm typecheck

--- a/.github/workflows/deploy-cf-preview.yml
+++ b/.github/workflows/deploy-cf-preview.yml
@@ -25,7 +25,9 @@ concurrency:
 jobs:
   build:
     name: Build
+    if: ${{ vars.DEPLOY_PROVIDER == 'cloudflare' && vars.ENABLE_PREVIEW_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -45,7 +47,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build static web app
         env:
@@ -67,13 +69,33 @@ jobs:
     name: Deploy to Cloudflare Pages
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Skip deploy for PRs from forks — secrets are not available there
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && vars.DEPLOY_PROVIDER == 'cloudflare' && vars.ENABLE_PREVIEW_DEPLOY == 'true' }}
     environment:
       name: dev
       url: ${{ steps.deploy.outputs.url }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.source_ref || github.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
@@ -89,4 +111,3 @@ jobs:
           projectName: ${{ vars.CF_PAGES_PROJECT_NAME || 'stixmagic-web' }}
           directory: apps/web/out
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/deploy-cf-production.yml
+++ b/.github/workflows/deploy-cf-production.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: ${{ vars.DEPLOY_PROVIDER == 'cloudflare' && vars.ENABLE_PROD_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}
@@ -37,7 +39,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build static web app
         env:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ vars.DEPLOY_PROVIDER == 'github-pages' && vars.ENABLE_PROD_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +35,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Configure custom domain (optional)
         env:
@@ -55,8 +57,10 @@ jobs:
           path: apps/web/out
 
   deploy:
+    if: ${{ vars.DEPLOY_PROVIDER == 'github-pages' && vars.ENABLE_PROD_DEPLOY == 'true' }}
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-preview-pages.yml
+++ b/.github/workflows/deploy-preview-pages.yml
@@ -19,7 +19,9 @@ concurrency:
 
 jobs:
   deploy-preview:
+    if: ${{ vars.DEPLOY_PROVIDER == 'external-pages' && vars.ENABLE_PREVIEW_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +40,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build static web app
         env:

--- a/.github/workflows/deploy-vercel-preview.yml
+++ b/.github/workflows/deploy-vercel-preview.yml
@@ -95,17 +95,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: web-out
-          path: apps/web/out
-
       - name: Install Vercel CLI
         run: pnpm install -g vercel@latest
 
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/web
+
+      - name: Build project
+        env:
+          NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL: ${{ vars.STIXMAGIC_MANIFEST_URL_DEV || vars.STIXMAGIC_MANIFEST_URL }}
+          NEXT_PUBLIC_STIXMAGIC_API_BASE_URL: ${{ vars.STIXMAGIC_API_BASE_URL_DEV || vars.STIXMAGIC_API_BASE_URL || 'https://preview.stixmagic.com' }}
+          NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL: ${{ vars.STIXMAGIC_PUBLIC_WEB_URL_DEV || vars.STIXMAGIC_PUBLIC_WEB_URL || 'https://preview.stixmagic.com' }}
+          NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME: ${{ vars.STIXMAGIC_BOT_USERNAME }}
+          NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL: ${{ vars.STIXMAGIC_MINI_APP_URL_DEV || vars.STIXMAGIC_MINI_APP_URL || 'https://preview.stixmagic.com/dashboard' }}
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: apps/web
 
       - name: Deploy to Vercel (preview)

--- a/.github/workflows/deploy-vercel-preview.yml
+++ b/.github/workflows/deploy-vercel-preview.yml
@@ -24,7 +24,9 @@ concurrency:
 jobs:
   build:
     name: Build
+    if: ${{ vars.DEPLOY_PROVIDER == 'vercel' && vars.ENABLE_PREVIEW_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -66,8 +68,9 @@ jobs:
     name: Deploy to Vercel (Preview)
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Skip deploy for PRs from forks — secrets are not available there
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && vars.DEPLOY_PROVIDER == 'vercel' && vars.ENABLE_PREVIEW_DEPLOY == 'true' }}
     environment:
       name: dev
       url: ${{ steps.deploy.outputs.url }}
@@ -88,6 +91,9 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Download build artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-vercel-production.yml
+++ b/.github/workflows/deploy-vercel-production.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to Vercel (Production)
+    if: ${{ vars.DEPLOY_PROVIDER == 'vercel' && vars.ENABLE_PROD_DEPLOY == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: production
       url: https://stixmagic.com
@@ -35,6 +37,9 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
         run: pnpm install -g vercel@latest

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ coverage/
 # Env
 .env
 apps/web/tsconfig.tsbuildinfo
+
+# Local API runtime data
+services/api/data/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ Recent backend work delivered a production-safe foundation for Telegram-facing t
 3. Add dead-letter and metrics around the job worker loop.
 4. Expand Telegram update handling coverage beyond message/sticker payloads.
 
+## Deployment and environment docs
+
+For deployment-safe setup and bot ecosystem integration contracts, see:
+
+- [`docs/deployment.md`](docs/deployment.md)
+- [`docs/environment_matrix.md`](docs/environment_matrix.md)
+- [`docs/integration_points.md`](docs/integration_points.md)
+
 ## Docs
 
 - [`infra/deploy/production-architecture.md`](infra/deploy/production-architecture.md)

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,90 @@
+# Deployment Guide
+
+This repository is a **pnpm/turbo monorepo** with a Next.js 14 static-export web app (`apps/web`) and supporting bot/API services.
+
+## 1) Build and output model
+
+- Web framework: **Next.js App Router** (`apps/web`).
+- Build mode: `output: 'export'` with `trailingSlash: true` and unoptimized images.
+- Static output directory: `apps/web/out`.
+- Root build command: `pnpm build` (runs turbo pipeline).
+- Web-only build command: `pnpm --filter @stixmagic/web build`.
+
+Because the web app is static-exported, deployment targets should be static hosting providers (Cloudflare Pages, Vercel static deploy, GitHub Pages, or external Pages repo).
+
+## 2) Deployment provider selection (GitHub Actions)
+
+The repository contains multiple deploy workflows. To avoid accidental multi-provider production deploys, workflows are now gated by repository variables:
+
+- `DEPLOY_PROVIDER`: one of `vercel`, `cloudflare`, `github-pages`, `external-pages`
+- `ENABLE_PROD_DEPLOY`: `true`/`false`
+- `ENABLE_PREVIEW_DEPLOY`: `true`/`false`
+
+### Recommended baseline
+
+- Production: `DEPLOY_PROVIDER=cloudflare` (or your chosen provider)
+- Preview: same provider or `external-pages`
+- Set:
+  - `ENABLE_PROD_DEPLOY=true`
+  - `ENABLE_PREVIEW_DEPLOY=true`
+
+If these variables are missing or mismatched, deploy jobs are skipped safely.
+
+## 3) Branch and environment behavior
+
+- `main` → production deploy workflows (when enabled).
+- `preview`, `dev` → preview/development deploy workflows (when enabled).
+- `pull_request` into `main` runs preview builds; secret-based deploy steps skip for forks.
+
+## 4) Provider-specific workflow summary
+
+### Vercel
+- Workflows:
+  - `.github/workflows/deploy-vercel-production.yml`
+  - `.github/workflows/deploy-vercel-preview.yml`
+- Required secret: `VERCEL_TOKEN`
+- Uses `vercel pull`, `vercel build`, `vercel deploy --prebuilt`.
+
+### Cloudflare Pages
+- Workflows:
+  - `.github/workflows/deploy-cf-production.yml`
+  - `.github/workflows/deploy-cf-preview.yml`
+- Required secrets:
+  - `CLOUDFLARE_API_TOKEN`
+  - `CLOUDFLARE_ACCOUNT_ID`
+- Required/optional vars:
+  - `CF_PAGES_PROJECT_NAME` (defaults to `stixmagic-web`)
+
+### GitHub Pages (same repo)
+- Workflow:
+  - `.github/workflows/deploy-pages.yml`
+- Uses GitHub Pages artifact + `actions/deploy-pages`.
+
+### External preview Pages repo
+- Workflow:
+  - `.github/workflows/deploy-preview-pages.yml`
+- Required secret: `PREVIEW_REPO_TOKEN`
+- Optional vars:
+  - `PREVIEW_PAGES_REPO`
+  - `PAGES_PREVIEW_DOMAIN`
+
+## 5) Pre-deploy checklist
+
+1. Configure required secrets for your selected provider.
+2. Configure environment variables in GitHub Actions repository variables.
+3. Set deploy gate variables (`DEPLOY_PROVIDER`, `ENABLE_*_DEPLOY`).
+4. Ensure `NEXT_PUBLIC_STIXMAGIC_*` values resolve to the target environment URLs.
+5. Confirm the Telegram bot username and Mini App URL pair is consistent with BotFather Mini App settings.
+
+## 6) Operational notes for bot ecosystem alignment
+
+- Bot and web must reference the same API origin (`STIXMAGIC_API_BASE_URL` / `NEXT_PUBLIC_STIXMAGIC_API_BASE_URL`).
+- Production webhook mode requires public HTTPS endpoint and webhook secret.
+- Mini App init-data validation depends on valid bot token + freshness window.
+
+## 7) Manual follow-up outside this repo
+
+- Register final Mini App URL in Telegram BotFather.
+- Configure HTTPS ingress for API webhook endpoint.
+- Provision Postgres + S3-compatible storage for production services.
+- Add environment protection rules in GitHub for `production` environment approvals if desired.

--- a/docs/environment_matrix.md
+++ b/docs/environment_matrix.md
@@ -1,0 +1,79 @@
+# Environment Variable Matrix
+
+This matrix documents development vs production expectations for STIX MΛGIC web, bot, and API surfaces.
+
+## Classification
+
+- **Public (client-visible):** `NEXT_PUBLIC_*` values are embedded in web bundles.
+- **Private (server-only):** secrets/tokens/DB credentials; never expose to browser.
+
+## Core runtime variables
+
+| Variable | Scope | Public? | Required (Dev) | Required (Prod) | Notes |
+|---|---|---:|---:|---:|---|
+| `NODE_ENV` | all | No | Yes | Yes | `development`/`test`/`production`. |
+| `WEB_PORT` | web runtime | No | Yes | Optional | Local `next dev/start` port. |
+| `API_PORT` | api | No | Yes | Optional | Local API listening port. |
+| `BOT_PORT` | bot | No | Yes | Optional | Local bot process port if needed by host. |
+| `STICKER_ENGINE_PORT` | sticker-engine | No | Yes | Optional | Local service port. |
+| `TRIGGER_ENGINE_PORT` | trigger-engine | No | Yes | Optional | Local service port. |
+
+## Infrastructure variables (private)
+
+| Variable | Service(s) | Required (Dev) | Required (Prod) | Notes |
+|---|---|---:|---:|---|
+| `POSTGRES_URL` | api, bot, engines | Yes | Yes | Persistent data backend. |
+| `S3_ENDPOINT` | api, bot, engines | Yes | Yes | S3-compatible endpoint. |
+| `S3_REGION` | api, bot, engines | Yes | Yes | Bucket region. |
+| `S3_BUCKET` | api, bot, engines | Yes | Yes | Asset bucket name. |
+| `S3_ACCESS_KEY` | api, bot, engines | Yes | Yes | Private credential. |
+| `S3_SECRET_KEY` | api, bot, engines | Yes | Yes | Private credential. |
+
+## Telegram + STIX platform variables
+
+| Variable | Surface | Public? | Required (Dev) | Required (Prod) | Notes |
+|---|---|---:|---:|---:|---|
+| `STIXMAGIC_PUBLIC_WEB_URL` | api/bot | No | Yes | Yes | Canonical web base URL. |
+| `STIXMAGIC_API_BASE_URL` | api/bot | No | Yes | Yes | Shared API base URL. |
+| `TELEGRAM_BOT_TOKEN` | bot/api validation | No | Yes | Yes | Secret token from BotFather. |
+| `TELEGRAM_BOT_USERNAME` | bot/web/api | No | Yes | Yes | Without `@` preferred. |
+| `TELEGRAM_MINI_APP_URL` | bot/api | No | Yes | Yes | Full Mini App URL used in bot handoff. |
+| `TELEGRAM_BOT_MODE` | bot/api | No | Yes | Yes | `polling` or `webhook`. |
+| `TELEGRAM_WEBHOOK_URL` | bot/api | No | No* | Yes (webhook mode) | Required when mode is `webhook`. |
+| `TELEGRAM_WEBHOOK_SECRET` | api webhook | No | Recommended | Yes | Strong random secret for webhook validation. |
+| `TELEGRAM_INIT_DATA_MAX_AGE_SECONDS` | api | No | Recommended | Yes | Replay/freshness control for Mini App init-data. |
+
+## Web client variables (public)
+
+| Variable | Required (Dev) | Required (Prod) | Notes |
+|---|---:|---:|---|
+| `NEXT_PUBLIC_STIXMAGIC_API_BASE_URL` | Yes | Yes | Client API origin. |
+| `NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL` | Yes | Yes | Public web origin. |
+| `NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME` | Yes | Yes | Bot deep-link UX. |
+| `NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL` | Yes | Yes | Client-visible app URL. |
+| `NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL` | Optional | Optional | Pipeline manifest endpoint; blank uses sample. |
+| `NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA` | Optional | Optional | `true` for demo fallback UI mode. |
+
+## CI/CD repository variables and secrets
+
+### Variables
+
+- `DEPLOY_PROVIDER` (`vercel`, `cloudflare`, `github-pages`, `external-pages`)
+- `ENABLE_PROD_DEPLOY` (`true`/`false`)
+- `ENABLE_PREVIEW_DEPLOY` (`true`/`false`)
+- `STIXMAGIC_*` and `STIXMAGIC_*_DEV` URL overrides for deploy workflows
+- `CF_PAGES_PROJECT_NAME`, `PAGES_CUSTOM_DOMAIN`, `PAGES_PREVIEW_DOMAIN`, `PREVIEW_PAGES_REPO`
+
+### Secrets
+
+- `VERCEL_TOKEN`
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+- `PREVIEW_REPO_TOKEN`
+
+## Recommended production baseline
+
+- `TELEGRAM_BOT_MODE=webhook`
+- `NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA=false`
+- Distinct production and preview URLs for API and Mini App
+- Unique webhook secret and strict environment protections in GitHub Actions

--- a/docs/environment_matrix.md
+++ b/docs/environment_matrix.md
@@ -17,6 +17,7 @@ This matrix documents development vs production expectations for STIX MΛGIC web
 | `BOT_PORT` | bot | No | Yes | Optional | Local bot process port if needed by host. |
 | `STICKER_ENGINE_PORT` | sticker-engine | No | Yes | Optional | Local service port. |
 | `TRIGGER_ENGINE_PORT` | trigger-engine | No | Yes | Optional | Local service port. |
+| `TRIGGER_ENGINE_URL` | bot | No | Yes | Optional | Base URL the bot uses to call the trigger engine (defaults to `http://localhost:4300`). |
 
 ## Infrastructure variables (private)
 

--- a/docs/environment_matrix.md
+++ b/docs/environment_matrix.md
@@ -39,7 +39,7 @@ This matrix documents development vs production expectations for STIX MΛGIC web
 | `TELEGRAM_BOT_USERNAME` | bot/web/api | No | Yes | Yes | Without `@` preferred. |
 | `TELEGRAM_MINI_APP_URL` | bot/api | No | Yes | Yes | Full Mini App URL used in bot handoff. |
 | `TELEGRAM_BOT_MODE` | bot/api | No | Yes | Yes | `polling` or `webhook`. |
-| `TELEGRAM_WEBHOOK_URL` | bot/api | No | No* | Yes (webhook mode) | Required when mode is `webhook`. |
+| `TELEGRAM_WEBHOOK_URL` | bot/api | No | No | Yes (webhook mode) | Required when mode is `webhook`; not needed in dev if using polling mode. |
 | `TELEGRAM_WEBHOOK_SECRET` | api webhook | No | Recommended | Yes | Strong random secret for webhook validation. |
 | `TELEGRAM_INIT_DATA_MAX_AGE_SECONDS` | api | No | Recommended | Yes | Replay/freshness control for Mini App init-data. |
 

--- a/docs/environment_matrix.md
+++ b/docs/environment_matrix.md
@@ -51,7 +51,7 @@ This matrix documents development vs production expectations for STIX MΛGIC web
 | `NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL` | Yes | Yes | Public web origin. |
 | `NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME` | Yes | Yes | Bot deep-link UX. |
 | `NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL` | Yes | Yes | Client-visible app URL. |
-| `NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL` | Optional | Optional | Pipeline manifest endpoint; blank uses sample. |
+| `NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL` | Optional | Optional | Pipeline manifest endpoint; leave **unset/omitted** to use sample data (do not set to an empty string). |
 | `NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA` | Optional | Optional | `true` for demo fallback UI mode. |
 
 ## CI/CD repository variables and secrets

--- a/docs/integration_points.md
+++ b/docs/integration_points.md
@@ -1,0 +1,89 @@
+# STIX MΛGIC Integration Points
+
+This document captures the explicit integration contract between the web mini app and the STIX MΛGIC bot/backend ecosystem.
+
+## 1) Surface topology
+
+- **Bot (`apps/bot`)**: Telegram command surface + Mini App handoff.
+- **Mini App (`apps/web`)**: operator UI for groups/rules/content workflows.
+- **API (`services/api`)**: shared contract boundary used by bot and mini app.
+- **Engines (`services/sticker-engine`, `services/trigger-engine`)**: async processing backends.
+
+## 2) API base URL contract
+
+All surfaces should point to one authoritative API base per environment:
+
+- Server-side: `STIXMAGIC_API_BASE_URL`
+- Client-side: `NEXT_PUBLIC_STIXMAGIC_API_BASE_URL`
+
+Mismatch here is a primary integration failure mode (UI loads but actions target wrong backend).
+
+## 3) Current API endpoints consumed/expected
+
+Mini app/API client paths in use:
+
+- `GET /telegram/mini-app/bootstrap`
+- `GET /groups`
+- `GET /groups/:groupId`
+- `GET /groups/:groupId/rules`
+- `POST /groups/:groupId/rules`
+- `PATCH /groups/:groupId/rules/:ruleId`
+- `DELETE /groups/:groupId/rules/:ruleId`
+
+Bot/API interactions in use:
+
+- `GET /packs`
+- `POST /internal/jobs/process-once` (internal process route)
+- Trigger execution service call via `TRIGGER_ENGINE_URL/execute`
+
+## 4) Telegram integration assumptions
+
+### Bot identity and links
+
+- `TELEGRAM_BOT_USERNAME` is used to generate deep links:
+  - `https://t.me/<botUsername>`
+  - `https://t.me/<botUsername>/app`
+
+### Mini App URL
+
+- `TELEGRAM_MINI_APP_URL` / `NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL` must align with the deployed UI URL and BotFather mini app configuration.
+
+### Runtime mode
+
+- `TELEGRAM_BOT_MODE=polling` for local/dev environments.
+- `TELEGRAM_BOT_MODE=webhook` for production; requires:
+  - public HTTPS webhook endpoint (`TELEGRAM_WEBHOOK_URL`)
+  - shared webhook secret (`TELEGRAM_WEBHOOK_SECRET`)
+
+### Init-data trust boundary
+
+- API validates Telegram Mini App init-data server-side.
+- Freshness tolerance controlled by `TELEGRAM_INIT_DATA_MAX_AGE_SECONDS`.
+
+## 5) Manifest/pipeline integration boundary
+
+The web app optionally consumes pipeline manifest data through:
+
+- `NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL` (public URL)
+
+If absent/unavailable, the app falls back to bundled sample data; this is acceptable for development but should be treated as degraded mode in production.
+
+## 6) Auth and admin assumptions
+
+- Admin-sensitive API operations rely on authenticated Telegram identity and explicit admin authorization middleware in the API service.
+- CORS is enabled in API (`origin: true`); production environments should additionally control allowed origins at edge/proxy layer.
+
+## 7) Webhook/public path expectations
+
+Expected public ingress paths in production deployment design:
+
+- API health: `/health`
+- Telegram webhook route(s): under API `telegram` route namespace
+- Mini App route: `/dashboard` (as configured by default URLs)
+
+## 8) Open integration follow-ups
+
+1. Move from permissive CORS to allowlist-based origin policy.
+2. Add explicit API version prefix strategy (e.g., `/v1`) before broad external integrations.
+3. Define SLOs and retry/backoff contracts between API and trigger/sticker engines.
+4. Add monitoring and dead-letter strategy for queued job processing routes.

--- a/docs/integration_points.md
+++ b/docs/integration_points.md
@@ -30,11 +30,13 @@ Mini app/API client paths in use:
 - `PATCH /groups/:groupId/rules/:ruleId`
 - `DELETE /groups/:groupId/rules/:ruleId`
 
-Bot/API interactions in use:
+Bot/API interactions and operator/debug endpoints:
 
 - `GET /packs`
-- `POST /internal/jobs/process-once` (internal process route)
-- Trigger execution service call via `TRIGGER_ENGINE_URL/execute`
+- Operator/debug job kick endpoint (not called by `apps/bot` at runtime):
+  - `POST /internal/jobs/process-once`
+  - Intended invocation: manual curl/Postman call by an operator, or from ad-hoc scripts, to force a single job-processing tick (primarily in non-production/debug environments).
+- Trigger execution service call via `TRIGGER_ENGINE_URL/execute` (invoked by API/engine services, not directly by the bot).
 
 ## 4) Telegram integration assumptions
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,9 @@ import type {
   TelegramSurfaceLinks
 } from '@stixmagic/types';
 
+/** Treat empty string as absent so unset GitHub Actions vars don't fail optional URL validation. */
+const optionalUrl = z.preprocess((v) => (v === '' ? undefined : v), z.string().url().optional());
+
 const baseSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   POSTGRES_URL: z.string().url(),
@@ -35,7 +38,7 @@ const webSchema = baseSchema.extend({
   NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME: z.string().min(1).optional(),
   NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL: z.string().url().optional(),
   NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL: z.string().url().optional(),
-  NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL: z.string().url().optional(),
+  NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL: optionalUrl,
   NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA: z.enum(['true', 'false']).optional()
 });
 
@@ -63,7 +66,7 @@ const telegramClientSchema = z.object({
   NEXT_PUBLIC_STIXMAGIC_BOT_USERNAME: z.string().min(1).default('StixMagicBot'),
   NEXT_PUBLIC_STIXMAGIC_MINI_APP_URL: z.string().url().default('http://localhost:3000/dashboard'),
   NEXT_PUBLIC_STIXMAGIC_PUBLIC_WEB_URL: z.string().url().default('http://localhost:3000'),
-  NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL: z.string().url().optional(),
+  NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL: optionalUrl,
   NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA: z.enum(['true', 'false']).default('false')
 });
 

--- a/services/api/src/tests/config.test.ts
+++ b/services/api/src/tests/config.test.ts
@@ -409,3 +409,330 @@ test('regression: every deploy workflow (except ci) has at least one DEPLOY_PROV
     assertContains(content, 'vars.DEPLOY_PROVIDER', file);
   }
 });
+
+// ---------------------------------------------------------------------------
+// apps/web/app/lib/api-client.ts — removed API-fallback surface
+// ---------------------------------------------------------------------------
+
+test('api-client.ts: isApiFallbackEnabled function is NOT exported', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertNotContains(content, 'isApiFallbackEnabled', 'api-client.ts');
+});
+
+test('api-client.ts: ALLOW_API_FALLBACK constant is NOT present', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertNotContains(content, 'ALLOW_API_FALLBACK', 'api-client.ts');
+});
+
+test('api-client.ts: resolveInitDataHeader function is NOT present', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertNotContains(content, 'resolveInitDataHeader', 'api-client.ts');
+});
+
+test('api-client.ts: buildDemoBootstrap helper function is NOT present', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertNotContains(content, 'buildDemoBootstrap', 'api-client.ts');
+});
+
+test('api-client.ts: apiFetch does not use new Headers() — uses plain object', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertNotContains(content, 'new Headers(', 'api-client.ts');
+});
+
+test('api-client.ts: apiFetch sets Content-Type application/json header', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertContains(content, "'Content-Type': 'application/json'", 'api-client.ts');
+});
+
+test('api-client.ts: NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK is NOT referenced', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertNotContains(content, 'NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK', 'api-client.ts');
+});
+
+test('api-client.ts: isDemoModeEnabled is still exported', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  assertContains(content, 'export function isDemoModeEnabled', 'api-client.ts');
+});
+
+test('api-client.ts: catch blocks for getGroups/getGroup/getRules return mock data unconditionally', () => {
+  const content = readFile('apps/web/app/lib/api-client.ts');
+  // Catch blocks should no longer gate on ALLOW_API_FALLBACK — they return mock directly.
+  // Verify the pattern: catch { return MOCK_GROUPS; } and catch { return MOCK_RULES[...]; }
+  assertContains(content, 'return MOCK_GROUPS;', 'api-client.ts getGroups fallback');
+  // getGroup fallback returns find result
+  assertContains(content, 'return MOCK_GROUPS.find', 'api-client.ts getGroup fallback');
+  // getRules fallback
+  assertContains(content, 'return MOCK_RULES[groupId]', 'api-client.ts getRules fallback');
+});
+
+// ---------------------------------------------------------------------------
+// apps/web/app/dashboard/page.tsx — removed fallback/error state
+// ---------------------------------------------------------------------------
+
+test('dashboard/page.tsx: does not import isApiFallbackEnabled', () => {
+  const content = readFile('apps/web/app/dashboard/page.tsx');
+  assertNotContains(content, 'isApiFallbackEnabled', 'apps/web/app/dashboard/page.tsx');
+});
+
+test('dashboard/page.tsx: does not reference ALLOW_API_FALLBACK', () => {
+  const content = readFile('apps/web/app/dashboard/page.tsx');
+  assertNotContains(content, 'ALLOW_API_FALLBACK', 'apps/web/app/dashboard/page.tsx');
+});
+
+test('dashboard/page.tsx: still imports isDemoModeEnabled', () => {
+  const content = readFile('apps/web/app/dashboard/page.tsx');
+  assertContains(content, 'isDemoModeEnabled', 'apps/web/app/dashboard/page.tsx');
+});
+
+test('dashboard/page.tsx: initializes groups state with MOCK_GROUPS', () => {
+  const content = readFile('apps/web/app/dashboard/page.tsx');
+  assertContains(content, 'useState<TelegramGroup[]>(MOCK_GROUPS)', 'apps/web/app/dashboard/page.tsx');
+});
+
+test('dashboard/page.tsx: errorMessage state is removed', () => {
+  const content = readFile('apps/web/app/dashboard/page.tsx');
+  assertNotContains(content, 'errorMessage', 'apps/web/app/dashboard/page.tsx');
+});
+
+// ---------------------------------------------------------------------------
+// apps/web/app/groups/page.tsx — removed fallback/error state
+// ---------------------------------------------------------------------------
+
+test('groups/page.tsx: does not import isApiFallbackEnabled', () => {
+  const content = readFile('apps/web/app/groups/page.tsx');
+  assertNotContains(content, 'isApiFallbackEnabled', 'apps/web/app/groups/page.tsx');
+});
+
+test('groups/page.tsx: does not import useMemo', () => {
+  const content = readFile('apps/web/app/groups/page.tsx');
+  assertNotContains(content, 'useMemo', 'apps/web/app/groups/page.tsx');
+});
+
+test('groups/page.tsx: initializes groups state with MOCK_GROUPS', () => {
+  const content = readFile('apps/web/app/groups/page.tsx');
+  assertContains(content, 'useState<TelegramGroup[]>(MOCK_GROUPS)', 'apps/web/app/groups/page.tsx');
+});
+
+// ---------------------------------------------------------------------------
+// apps/web/app/groups/[group_id]/GroupView.tsx — simplified data loading
+// ---------------------------------------------------------------------------
+
+test('GroupView.tsx: does not import isApiFallbackEnabled', () => {
+  const content = readFile('apps/web/app/groups/[group_id]/GroupView.tsx');
+  assertNotContains(content, 'isApiFallbackEnabled', 'GroupView.tsx');
+});
+
+test('GroupView.tsx: does not import useMemo', () => {
+  const content = readFile('apps/web/app/groups/[group_id]/GroupView.tsx');
+  assertNotContains(content, 'useMemo', 'GroupView.tsx');
+});
+
+test('GroupView.tsx: fallbackGroup resolves directly from MOCK_GROUPS without allowFallback guard', () => {
+  const content = readFile('apps/web/app/groups/[group_id]/GroupView.tsx');
+  // allowFallback variable should not exist
+  assertNotContains(content, 'allowFallback', 'GroupView.tsx');
+});
+
+// ---------------------------------------------------------------------------
+// apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx — simplified useEffect
+// ---------------------------------------------------------------------------
+
+test('ReactionsEditor.tsx: does not reference isApiFallbackEnabled', () => {
+  const content = readFile('apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx');
+  assertNotContains(content, 'isApiFallbackEnabled', 'ReactionsEditor.tsx');
+});
+
+test('ReactionsEditor.tsx: loads rules using getRules().then() promise chain', () => {
+  const content = readFile('apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx');
+  assertContains(content, 'getRules(groupId).then', 'ReactionsEditor.tsx');
+});
+
+test('ReactionsEditor.tsx: error state from catch block (setError) is removed', () => {
+  const content = readFile('apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx');
+  // The old loadRules() set an error message via setError in catch block
+  // The simplified version does not use try/catch at all in the useEffect
+  assertNotContains(content, "setError(`Failed to load reaction rules", 'ReactionsEditor.tsx');
+});
+
+// ---------------------------------------------------------------------------
+// packages/config/src/index.ts — schema changes
+// ---------------------------------------------------------------------------
+
+test('packages/config/src/index.ts: NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK is NOT in telegramClientSchema', () => {
+  const content = readFile('packages/config/src/index.ts');
+  assertNotContains(content, 'NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK', 'packages/config/src/index.ts');
+});
+
+test('packages/config/src/index.ts: TELEGRAM_INIT_DATA_MAX_AGE_SECONDS is in telegramSharedSchema with default 3600', () => {
+  const content = readFile('packages/config/src/index.ts');
+  assertContains(content, 'TELEGRAM_INIT_DATA_MAX_AGE_SECONDS', 'packages/config/src/index.ts');
+  assertContains(content, '.default(3600)', 'packages/config/src/index.ts');
+});
+
+test('packages/config/src/index.ts: TELEGRAM_WEBHOOK_SECRET is in telegramSharedSchema', () => {
+  const content = readFile('packages/config/src/index.ts');
+  assertContains(content, 'TELEGRAM_WEBHOOK_SECRET', 'packages/config/src/index.ts');
+});
+
+test('packages/config/src/index.ts: NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA is in telegramClientSchema with default false', () => {
+  const content = readFile('packages/config/src/index.ts');
+  assertContains(content, 'NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA', 'packages/config/src/index.ts');
+  assertContains(content, ".default('false')", 'packages/config/src/index.ts');
+});
+
+test('packages/config/src/index.ts: loadTelegramClientEnv is exported', () => {
+  const content = readFile('packages/config/src/index.ts');
+  assertContains(content, 'export const loadTelegramClientEnv', 'packages/config/src/index.ts');
+});
+
+test('packages/config/src/index.ts: telegramClientSchema has exactly 6 NEXT_PUBLIC fields (no ALLOW_API_FALLBACK)', () => {
+  const content = readFile('packages/config/src/index.ts');
+  // Extract the telegramClientSchema block
+  const schemaStart = content.indexOf('const telegramClientSchema = z.object({');
+  const schemaEnd = content.indexOf('});', schemaStart);
+  assert.ok(schemaStart !== -1, 'packages/config/src/index.ts: telegramClientSchema block not found');
+  const schemaBlock = content.slice(schemaStart, schemaEnd);
+  const fieldMatches = schemaBlock.match(/NEXT_PUBLIC_\w+/g) ?? [];
+  const uniqueFields = [...new Set(fieldMatches)];
+  assert.equal(
+    uniqueFields.length,
+    6,
+    `packages/config/src/index.ts: expected 6 NEXT_PUBLIC fields in telegramClientSchema, found: ${uniqueFields.join(', ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// apps/web/package.json — lint/typecheck script and eslint dep changes
+// ---------------------------------------------------------------------------
+
+test('apps/web/package.json: is valid JSON', () => {
+  const content = readFile('apps/web/package.json');
+  assert.doesNotThrow(() => JSON.parse(content), 'apps/web/package.json must be valid JSON');
+});
+
+test('apps/web/package.json: lint script uses next lint', () => {
+  const content = readFile('apps/web/package.json');
+  const pkg = JSON.parse(content) as { scripts?: Record<string, string> };
+  assert.equal(pkg.scripts?.lint, 'next lint', 'apps/web/package.json: lint script should be "next lint"');
+});
+
+test('apps/web/package.json: typecheck script uses -p tsconfig.json flag', () => {
+  const content = readFile('apps/web/package.json');
+  const pkg = JSON.parse(content) as { scripts?: Record<string, string> };
+  assert.ok(
+    pkg.scripts?.typecheck?.includes('-p tsconfig.json'),
+    `apps/web/package.json: typecheck should include "-p tsconfig.json", got: ${pkg.scripts?.typecheck}`,
+  );
+});
+
+test('apps/web/package.json: eslint is NOT in devDependencies', () => {
+  const content = readFile('apps/web/package.json');
+  const pkg = JSON.parse(content) as { devDependencies?: Record<string, string> };
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(pkg.devDependencies ?? {}, 'eslint'),
+    'apps/web/package.json: eslint should not be in devDependencies after migration to next lint',
+  );
+});
+
+test('apps/web/package.json: eslint-config-next is NOT in devDependencies', () => {
+  const content = readFile('apps/web/package.json');
+  const pkg = JSON.parse(content) as { devDependencies?: Record<string, string> };
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(pkg.devDependencies ?? {}, 'eslint-config-next'),
+    'apps/web/package.json: eslint-config-next should not be in devDependencies',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// turbo.json — test task removed, lint/typecheck remain
+// ---------------------------------------------------------------------------
+
+test('turbo.json: is valid JSON', () => {
+  const content = readFile('turbo.json');
+  assert.doesNotThrow(() => JSON.parse(content), 'turbo.json must be valid JSON');
+});
+
+test('turbo.json: does NOT contain a test task', () => {
+  const content = readFile('turbo.json');
+  const turbo = JSON.parse(content) as { tasks?: Record<string, unknown> };
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(turbo.tasks ?? {}, 'test'),
+    'turbo.json: "test" task should have been removed from the pipeline',
+  );
+});
+
+test('turbo.json: lint task is present', () => {
+  const content = readFile('turbo.json');
+  const turbo = JSON.parse(content) as { tasks?: Record<string, unknown> };
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(turbo.tasks ?? {}, 'lint'),
+    'turbo.json: "lint" task must be present',
+  );
+});
+
+test('turbo.json: typecheck task is present', () => {
+  const content = readFile('turbo.json');
+  const turbo = JSON.parse(content) as { tasks?: Record<string, unknown> };
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(turbo.tasks ?? {}, 'typecheck'),
+    'turbo.json: "typecheck" task must be present',
+  );
+});
+
+test('turbo.json: build task is present with outputs configuration', () => {
+  const content = readFile('turbo.json');
+  const turbo = JSON.parse(content) as { tasks?: Record<string, { outputs?: string[] }> };
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(turbo.tasks ?? {}, 'build'),
+    'turbo.json: "build" task must be present',
+  );
+  const outputs = turbo.tasks?.build?.outputs ?? [];
+  assert.ok(outputs.length > 0, 'turbo.json: build task must declare outputs');
+});
+
+// ---------------------------------------------------------------------------
+// Regression: .env.example no longer references removed vars
+// ---------------------------------------------------------------------------
+
+test('.env.example: NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK is NOT present', () => {
+  const content = readFile('.env.example');
+  assertNotContains(content, 'NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK', '.env.example');
+});
+
+test('.env.example: STIXMAGIC_ALLOW_API_FALLBACK is NOT present', () => {
+  const content = readFile('.env.example');
+  assertNotContains(content, 'STIXMAGIC_ALLOW_API_FALLBACK', '.env.example');
+});
+
+// ---------------------------------------------------------------------------
+// Regression: cross-file — no changed file re-introduces removed identifiers
+// ---------------------------------------------------------------------------
+
+const CHANGED_WEB_FILES = [
+  'apps/web/app/dashboard/page.tsx',
+  'apps/web/app/groups/page.tsx',
+  'apps/web/app/groups/[group_id]/GroupView.tsx',
+  'apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx',
+  'apps/web/app/lib/api-client.ts',
+];
+
+test('regression: no changed web file references isApiFallbackEnabled', () => {
+  for (const file of CHANGED_WEB_FILES) {
+    const content = readFile(file);
+    assertNotContains(content, 'isApiFallbackEnabled', file);
+  }
+});
+
+test('regression: no changed web file references ALLOW_API_FALLBACK', () => {
+  for (const file of CHANGED_WEB_FILES) {
+    const content = readFile(file);
+    assertNotContains(content, 'ALLOW_API_FALLBACK', file);
+  }
+});
+
+test('regression: no changed web file references NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK', () => {
+  for (const file of CHANGED_WEB_FILES) {
+    const content = readFile(file);
+    assertNotContains(content, 'NEXT_PUBLIC_STIXMAGIC_ALLOW_API_FALLBACK', file);
+  }
+});

--- a/services/api/src/tests/config.test.ts
+++ b/services/api/src/tests/config.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for PR: Hardened deployment workflows and documented env/integration model.
+ *
+ * Validates that the changed config files satisfy the structural and content
+ * requirements introduced by this pull request:
+ *   - Workflow gate conditions (DEPLOY_PROVIDER, ENABLE_*_DEPLOY)
+ *   - timeout-minutes: 20 on every job
+ *   - pnpm install --frozen-lockfile everywhere (no bare pnpm install)
+ *   - New .env.example variables (TELEGRAM_INIT_DATA_MAX_AGE_SECONDS, TELEGRAM_WEBHOOK_SECRET)
+ *   - .gitignore entry for services/api/data/
+ *   - apps/web/.eslintrc.json extending next/core-web-vitals
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+// Resolve the monorepo root relative to this test file's location.
+// Path: services/api/src/tests/config.test.ts -> up 4 levels -> repo root
+const ROOT = fileURLToPath(new URL('../../../../', import.meta.url));
+
+function readFile(relativePath: string): string {
+  return readFileSync(join(ROOT, relativePath), 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Assert a string contains a substring, with a helpful message. */
+function assertContains(haystack: string, needle: string, label: string): void {
+  assert.ok(
+    haystack.includes(needle),
+    `${label}: expected to contain ${JSON.stringify(needle)}`,
+  );
+}
+
+/** Assert a string does NOT contain a substring. */
+function assertNotContains(haystack: string, needle: string, label: string): void {
+  assert.ok(
+    !haystack.includes(needle),
+    `${label}: must NOT contain ${JSON.stringify(needle)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ci.yml
+// ---------------------------------------------------------------------------
+
+test('ci.yml: validate job has timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/ci.yml');
+  assertContains(content, 'timeout-minutes: 20', 'ci.yml');
+});
+
+test('ci.yml: install step uses --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/ci.yml');
+  assertContains(content, 'pnpm install --frozen-lockfile', 'ci.yml');
+});
+
+test('ci.yml: no bare pnpm install without --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/ci.yml');
+  // Lines that contain "pnpm install" must all include "--frozen-lockfile".
+  // (pnpm install -g vercel is allowed because it is a global CLI tool install.)
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `ci.yml: found bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// deploy-cf-preview.yml
+// ---------------------------------------------------------------------------
+
+test('deploy-cf-preview.yml: build job gated by DEPLOY_PROVIDER == cloudflare and ENABLE_PREVIEW_DEPLOY', () => {
+  const content = readFile('.github/workflows/deploy-cf-preview.yml');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'cloudflare'", 'deploy-cf-preview.yml build if');
+  assertContains(content, "vars.ENABLE_PREVIEW_DEPLOY == 'true'", 'deploy-cf-preview.yml build if');
+});
+
+test('deploy-cf-preview.yml: deploy job if condition guards forks and checks provider/enable vars', () => {
+  const content = readFile('.github/workflows/deploy-cf-preview.yml');
+  assertContains(content, 'github.event.pull_request.head.repo.fork == false', 'deploy-cf-preview.yml deploy if fork guard');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'cloudflare'", 'deploy-cf-preview.yml deploy if provider');
+  assertContains(content, "vars.ENABLE_PREVIEW_DEPLOY == 'true'", 'deploy-cf-preview.yml deploy if enable');
+});
+
+test('deploy-cf-preview.yml: both jobs have timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/deploy-cf-preview.yml');
+  const matches = (content.match(/timeout-minutes:\s*20/g) ?? []).length;
+  assert.ok(matches >= 2, `deploy-cf-preview.yml: expected at least 2 timeout-minutes: 20 entries, found ${matches}`);
+});
+
+test('deploy-cf-preview.yml: all install steps use --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/deploy-cf-preview.yml');
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `deploy-cf-preview.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+test('deploy-cf-preview.yml: deploy job includes a checkout step', () => {
+  const content = readFile('.github/workflows/deploy-cf-preview.yml');
+  // The deploy job section starts after "deploy:" job heading.
+  const deploySection = content.slice(content.indexOf('\n  deploy:'));
+  assertContains(deploySection, 'actions/checkout@v4', 'deploy-cf-preview.yml deploy job checkout');
+});
+
+// ---------------------------------------------------------------------------
+// deploy-cf-production.yml
+// ---------------------------------------------------------------------------
+
+test('deploy-cf-production.yml: build-and-deploy job gated by DEPLOY_PROVIDER == cloudflare and ENABLE_PROD_DEPLOY', () => {
+  const content = readFile('.github/workflows/deploy-cf-production.yml');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'cloudflare'", 'deploy-cf-production.yml');
+  assertContains(content, "vars.ENABLE_PROD_DEPLOY == 'true'", 'deploy-cf-production.yml');
+});
+
+test('deploy-cf-production.yml: job has timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/deploy-cf-production.yml');
+  assertContains(content, 'timeout-minutes: 20', 'deploy-cf-production.yml');
+});
+
+test('deploy-cf-production.yml: install step uses --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/deploy-cf-production.yml');
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `deploy-cf-production.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// deploy-pages.yml
+// ---------------------------------------------------------------------------
+
+test('deploy-pages.yml: build job gated by DEPLOY_PROVIDER == github-pages and ENABLE_PROD_DEPLOY', () => {
+  const content = readFile('.github/workflows/deploy-pages.yml');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'github-pages'", 'deploy-pages.yml build if');
+  assertContains(content, "vars.ENABLE_PROD_DEPLOY == 'true'", 'deploy-pages.yml build if');
+});
+
+test('deploy-pages.yml: deploy job also has gate condition (not just build)', () => {
+  const content = readFile('.github/workflows/deploy-pages.yml');
+  // Both jobs should be gated. Count occurrences.
+  const providerMatches = (content.match(/vars\.DEPLOY_PROVIDER == 'github-pages'/g) ?? []).length;
+  assert.ok(
+    providerMatches >= 2,
+    `deploy-pages.yml: expected DEPLOY_PROVIDER guard on both build and deploy jobs, found ${providerMatches}`,
+  );
+});
+
+test('deploy-pages.yml: both jobs have timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/deploy-pages.yml');
+  const matches = (content.match(/timeout-minutes:\s*20/g) ?? []).length;
+  assert.ok(matches >= 2, `deploy-pages.yml: expected at least 2 timeout-minutes entries, found ${matches}`);
+});
+
+test('deploy-pages.yml: install step uses --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/deploy-pages.yml');
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `deploy-pages.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// deploy-preview-pages.yml
+// ---------------------------------------------------------------------------
+
+test('deploy-preview-pages.yml: job gated by DEPLOY_PROVIDER == external-pages and ENABLE_PREVIEW_DEPLOY', () => {
+  const content = readFile('.github/workflows/deploy-preview-pages.yml');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'external-pages'", 'deploy-preview-pages.yml');
+  assertContains(content, "vars.ENABLE_PREVIEW_DEPLOY == 'true'", 'deploy-preview-pages.yml');
+});
+
+test('deploy-preview-pages.yml: job has timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/deploy-preview-pages.yml');
+  assertContains(content, 'timeout-minutes: 20', 'deploy-preview-pages.yml');
+});
+
+test('deploy-preview-pages.yml: install step uses --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/deploy-preview-pages.yml');
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `deploy-preview-pages.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+test('deploy-preview-pages.yml: file ends with newline (no missing trailing newline)', () => {
+  const content = readFile('.github/workflows/deploy-preview-pages.yml');
+  assert.ok(content.endsWith('\n'), 'deploy-preview-pages.yml: file should end with a newline');
+});
+
+// ---------------------------------------------------------------------------
+// deploy-vercel-preview.yml
+// ---------------------------------------------------------------------------
+
+test('deploy-vercel-preview.yml: build job gated by DEPLOY_PROVIDER == vercel and ENABLE_PREVIEW_DEPLOY', () => {
+  const content = readFile('.github/workflows/deploy-vercel-preview.yml');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'vercel'", 'deploy-vercel-preview.yml build if');
+  assertContains(content, "vars.ENABLE_PREVIEW_DEPLOY == 'true'", 'deploy-vercel-preview.yml build if');
+});
+
+test('deploy-vercel-preview.yml: deploy job guards forks and checks provider/enable vars', () => {
+  const content = readFile('.github/workflows/deploy-vercel-preview.yml');
+  assertContains(content, 'github.event.pull_request.head.repo.fork == false', 'deploy-vercel-preview.yml deploy if fork guard');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'vercel'", 'deploy-vercel-preview.yml deploy if provider');
+  assertContains(content, "vars.ENABLE_PREVIEW_DEPLOY == 'true'", 'deploy-vercel-preview.yml deploy if enable');
+});
+
+test('deploy-vercel-preview.yml: both jobs have timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/deploy-vercel-preview.yml');
+  const matches = (content.match(/timeout-minutes:\s*20/g) ?? []).length;
+  assert.ok(matches >= 2, `deploy-vercel-preview.yml: expected at least 2 timeout-minutes entries, found ${matches}`);
+});
+
+test('deploy-vercel-preview.yml: all install steps use --frozen-lockfile', () => {
+  const content = readFile('.github/workflows/deploy-vercel-preview.yml');
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `deploy-vercel-preview.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+test('deploy-vercel-preview.yml: deploy job includes pnpm install --frozen-lockfile step', () => {
+  const content = readFile('.github/workflows/deploy-vercel-preview.yml');
+  // The deploy job section starts after "  deploy:" heading.
+  const deploySection = content.slice(content.indexOf('\n  deploy:'));
+  assertContains(deploySection, 'pnpm install --frozen-lockfile', 'deploy-vercel-preview.yml deploy job install');
+});
+
+// ---------------------------------------------------------------------------
+// deploy-vercel-production.yml
+// ---------------------------------------------------------------------------
+
+test('deploy-vercel-production.yml: deploy job gated by DEPLOY_PROVIDER == vercel and ENABLE_PROD_DEPLOY', () => {
+  const content = readFile('.github/workflows/deploy-vercel-production.yml');
+  assertContains(content, "vars.DEPLOY_PROVIDER == 'vercel'", 'deploy-vercel-production.yml');
+  assertContains(content, "vars.ENABLE_PROD_DEPLOY == 'true'", 'deploy-vercel-production.yml');
+});
+
+test('deploy-vercel-production.yml: job has timeout-minutes: 20', () => {
+  const content = readFile('.github/workflows/deploy-vercel-production.yml');
+  assertContains(content, 'timeout-minutes: 20', 'deploy-vercel-production.yml');
+});
+
+test('deploy-vercel-production.yml: includes pnpm install --frozen-lockfile step', () => {
+  const content = readFile('.github/workflows/deploy-vercel-production.yml');
+  assertContains(content, 'pnpm install --frozen-lockfile', 'deploy-vercel-production.yml');
+});
+
+test('deploy-vercel-production.yml: no bare pnpm install without --frozen-lockfile or -g', () => {
+  const content = readFile('.github/workflows/deploy-vercel-production.yml');
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `deploy-vercel-production.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Cross-workflow: provider exclusivity
+// ---------------------------------------------------------------------------
+
+test('cloudflare workflow does not reference vercel provider', () => {
+  const cf = readFile('.github/workflows/deploy-cf-production.yml');
+  assertNotContains(cf, "vars.DEPLOY_PROVIDER == 'vercel'", 'deploy-cf-production.yml');
+});
+
+test('vercel workflow does not reference cloudflare provider', () => {
+  const vercel = readFile('.github/workflows/deploy-vercel-production.yml');
+  assertNotContains(vercel, "vars.DEPLOY_PROVIDER == 'cloudflare'", 'deploy-vercel-production.yml');
+});
+
+test('github-pages workflow does not reference cloudflare or vercel provider', () => {
+  const pages = readFile('.github/workflows/deploy-pages.yml');
+  assertNotContains(pages, "vars.DEPLOY_PROVIDER == 'cloudflare'", 'deploy-pages.yml');
+  assertNotContains(pages, "vars.DEPLOY_PROVIDER == 'vercel'", 'deploy-pages.yml');
+});
+
+// ---------------------------------------------------------------------------
+// .env.example
+// ---------------------------------------------------------------------------
+
+test('.env.example: contains TELEGRAM_INIT_DATA_MAX_AGE_SECONDS with default of 3600', () => {
+  const content = readFile('.env.example');
+  assertContains(content, 'TELEGRAM_INIT_DATA_MAX_AGE_SECONDS=3600', '.env.example');
+});
+
+test('.env.example: documents TELEGRAM_WEBHOOK_SECRET as a commented variable', () => {
+  const content = readFile('.env.example');
+  assertContains(content, 'TELEGRAM_WEBHOOK_SECRET', '.env.example');
+});
+
+test('.env.example: contains TELEGRAM_BOT_MODE=polling default', () => {
+  const content = readFile('.env.example');
+  assertContains(content, 'TELEGRAM_BOT_MODE=polling', '.env.example');
+});
+
+test('.env.example: documents NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA with false default', () => {
+  const content = readFile('.env.example');
+  assertContains(content, 'NEXT_PUBLIC_STIXMAGIC_USE_DEMO_DATA=false', '.env.example');
+});
+
+test('.env.example: documents DEPLOY_PROVIDER, ENABLE_PROD_DEPLOY, ENABLE_PREVIEW_DEPLOY CI/CD variables', () => {
+  const content = readFile('.env.example');
+  assertContains(content, 'DEPLOY_PROVIDER', '.env.example');
+  assertContains(content, 'ENABLE_PROD_DEPLOY', '.env.example');
+  assertContains(content, 'ENABLE_PREVIEW_DEPLOY', '.env.example');
+});
+
+test('.env.example: NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL is present (even if empty)', () => {
+  const content = readFile('.env.example');
+  assertContains(content, 'NEXT_PUBLIC_STIXMAGIC_MANIFEST_URL=', '.env.example');
+});
+
+test('.env.example: TELEGRAM_WEBHOOK_URL is commented out by default (not active)', () => {
+  const content = readFile('.env.example');
+  // Every line containing TELEGRAM_WEBHOOK_URL should be a comment.
+  const lines = content.split('\n').filter((l) => l.includes('TELEGRAM_WEBHOOK_URL'));
+  assert.ok(lines.length > 0, '.env.example: TELEGRAM_WEBHOOK_URL entry should exist');
+  const activeLines = lines.filter((l) => !l.trimStart().startsWith('#'));
+  assert.equal(
+    activeLines.length,
+    0,
+    `.env.example: TELEGRAM_WEBHOOK_URL should be commented out, found active: ${activeLines.join('; ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// .gitignore
+// ---------------------------------------------------------------------------
+
+test('.gitignore: includes services/api/data/ to exclude local API runtime data', () => {
+  const content = readFile('.gitignore');
+  assertContains(content, 'services/api/data/', '.gitignore');
+});
+
+test('.gitignore: still ignores .env file', () => {
+  const content = readFile('.gitignore');
+  // Plain ".env" line should be present
+  const lines = content.split('\n');
+  const hasEnv = lines.some((l) => l.trim() === '.env');
+  assert.ok(hasEnv, '.gitignore: must still contain a .env entry');
+});
+
+// ---------------------------------------------------------------------------
+// apps/web/.eslintrc.json
+// ---------------------------------------------------------------------------
+
+test('apps/web/.eslintrc.json: is valid JSON', () => {
+  const content = readFile('apps/web/.eslintrc.json');
+  assert.doesNotThrow(() => JSON.parse(content), 'apps/web/.eslintrc.json must be valid JSON');
+});
+
+test('apps/web/.eslintrc.json: extends next/core-web-vitals', () => {
+  const content = readFile('apps/web/.eslintrc.json');
+  const config = JSON.parse(content) as { extends?: string | string[] };
+  const extendsField = Array.isArray(config.extends)
+    ? config.extends
+    : [config.extends];
+  assert.ok(
+    extendsField.includes('next/core-web-vitals'),
+    `apps/web/.eslintrc.json: "extends" should include "next/core-web-vitals", got: ${JSON.stringify(config.extends)}`,
+  );
+});
+
+test('apps/web/.eslintrc.json: only contains expected keys', () => {
+  const content = readFile('apps/web/.eslintrc.json');
+  const config = JSON.parse(content) as Record<string, unknown>;
+  const keys = Object.keys(config);
+  assert.ok(
+    keys.includes('extends'),
+    'apps/web/.eslintrc.json: must have "extends" key',
+  );
+  // Boundary: no accidental rule overrides or unexpected top-level keys were introduced
+  const unexpectedKeys = keys.filter((k) => !['extends', 'rules', 'plugins', 'env', 'settings', 'overrides', 'parser', 'parserOptions'].includes(k));
+  assert.equal(
+    unexpectedKeys.length,
+    0,
+    `apps/web/.eslintrc.json: unexpected keys: ${unexpectedKeys.join(', ')}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Regression: no workflow still uses bare "pnpm install" without flags
+// ---------------------------------------------------------------------------
+
+const WORKFLOW_FILES = [
+  '.github/workflows/ci.yml',
+  '.github/workflows/deploy-cf-preview.yml',
+  '.github/workflows/deploy-cf-production.yml',
+  '.github/workflows/deploy-pages.yml',
+  '.github/workflows/deploy-preview-pages.yml',
+  '.github/workflows/deploy-vercel-preview.yml',
+  '.github/workflows/deploy-vercel-production.yml',
+];
+
+test('regression: no workflow uses bare pnpm install (all use --frozen-lockfile or -g flag)', () => {
+  for (const file of WORKFLOW_FILES) {
+    const content = readFile(file);
+    const bareInstall = content
+      .split('\n')
+      .filter(
+        (line) =>
+          /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+          !line.trimStart().startsWith('#'),
+      );
+    assert.equal(
+      bareInstall.length,
+      0,
+      `${file}: found bare pnpm install lines: ${bareInstall.join('; ')}`,
+    );
+  }
+});
+
+test('regression: every deploy workflow (except ci) has at least one DEPLOY_PROVIDER condition', () => {
+  const deployWorkflows = WORKFLOW_FILES.filter((f) => f.includes('deploy-'));
+  for (const file of deployWorkflows) {
+    const content = readFile(file);
+    assertContains(content, 'vars.DEPLOY_PROVIDER', file);
+  }
+});

--- a/services/api/src/tests/config.test.ts
+++ b/services/api/src/tests/config.test.ts
@@ -45,6 +45,22 @@ function assertNotContains(haystack: string, needle: string, label: string): voi
   );
 }
 
+/** Assert that content has no bare pnpm install (without --frozen-lockfile or -g). */
+function assertNoBarePnpmInstall(content: string, label: string): void {
+  const bareInstall = content
+    .split('\n')
+    .filter(
+      (line) =>
+        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
+        !line.trimStart().startsWith('#'),
+    );
+  assert.equal(
+    bareInstall.length,
+    0,
+    `${label}: found bare pnpm install lines: ${bareInstall.join('; ')}`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // ci.yml
 // ---------------------------------------------------------------------------
@@ -63,18 +79,7 @@ test('ci.yml: no bare pnpm install without --frozen-lockfile', () => {
   const content = readFile('.github/workflows/ci.yml');
   // Lines that contain "pnpm install" must all include "--frozen-lockfile".
   // (pnpm install -g vercel is allowed because it is a global CLI tool install.)
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `ci.yml: found bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'ci.yml');
 });
 
 // ---------------------------------------------------------------------------
@@ -102,24 +107,15 @@ test('deploy-cf-preview.yml: both jobs have timeout-minutes: 20', () => {
 
 test('deploy-cf-preview.yml: all install steps use --frozen-lockfile', () => {
   const content = readFile('.github/workflows/deploy-cf-preview.yml');
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `deploy-cf-preview.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'deploy-cf-preview.yml');
 });
 
 test('deploy-cf-preview.yml: deploy job includes a checkout step', () => {
   const content = readFile('.github/workflows/deploy-cf-preview.yml');
   // The deploy job section starts after "deploy:" job heading.
-  const deploySection = content.slice(content.indexOf('\n  deploy:'));
+  const idx = content.indexOf('\n  deploy:');
+  assert.ok(idx !== -1, 'deploy-cf-preview.yml: deploy job section not found');
+  const deploySection = content.slice(idx);
   assertContains(deploySection, 'actions/checkout@v4', 'deploy-cf-preview.yml deploy job checkout');
 });
 
@@ -140,18 +136,7 @@ test('deploy-cf-production.yml: job has timeout-minutes: 20', () => {
 
 test('deploy-cf-production.yml: install step uses --frozen-lockfile', () => {
   const content = readFile('.github/workflows/deploy-cf-production.yml');
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `deploy-cf-production.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'deploy-cf-production.yml');
 });
 
 // ---------------------------------------------------------------------------
@@ -182,18 +167,7 @@ test('deploy-pages.yml: both jobs have timeout-minutes: 20', () => {
 
 test('deploy-pages.yml: install step uses --frozen-lockfile', () => {
   const content = readFile('.github/workflows/deploy-pages.yml');
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `deploy-pages.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'deploy-pages.yml');
 });
 
 // ---------------------------------------------------------------------------
@@ -213,18 +187,7 @@ test('deploy-preview-pages.yml: job has timeout-minutes: 20', () => {
 
 test('deploy-preview-pages.yml: install step uses --frozen-lockfile', () => {
   const content = readFile('.github/workflows/deploy-preview-pages.yml');
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `deploy-preview-pages.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'deploy-preview-pages.yml');
 });
 
 test('deploy-preview-pages.yml: file ends with newline (no missing trailing newline)', () => {
@@ -257,18 +220,7 @@ test('deploy-vercel-preview.yml: both jobs have timeout-minutes: 20', () => {
 
 test('deploy-vercel-preview.yml: all install steps use --frozen-lockfile', () => {
   const content = readFile('.github/workflows/deploy-vercel-preview.yml');
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `deploy-vercel-preview.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'deploy-vercel-preview.yml');
 });
 
 test('deploy-vercel-preview.yml: deploy job includes pnpm install --frozen-lockfile step', () => {
@@ -300,18 +252,7 @@ test('deploy-vercel-production.yml: includes pnpm install --frozen-lockfile step
 
 test('deploy-vercel-production.yml: no bare pnpm install without --frozen-lockfile or -g', () => {
   const content = readFile('.github/workflows/deploy-vercel-production.yml');
-  const bareInstall = content
-    .split('\n')
-    .filter(
-      (line) =>
-        /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-        !line.trimStart().startsWith('#'),
-    );
-  assert.equal(
-    bareInstall.length,
-    0,
-    `deploy-vercel-production.yml: bare pnpm install lines: ${bareInstall.join('; ')}`,
-  );
+  assertNoBarePnpmInstall(content, 'deploy-vercel-production.yml');
 });
 
 // ---------------------------------------------------------------------------
@@ -430,7 +371,7 @@ test('apps/web/.eslintrc.json: only contains expected keys', () => {
     'apps/web/.eslintrc.json: must have "extends" key',
   );
   // Boundary: no accidental rule overrides or unexpected top-level keys were introduced
-  const unexpectedKeys = keys.filter((k) => !['extends', 'rules', 'plugins', 'env', 'settings', 'overrides', 'parser', 'parserOptions'].includes(k));
+  const unexpectedKeys = keys.filter((k) => !['extends', 'rules', 'plugins', 'env', 'settings', 'overrides', 'parser', 'parserOptions', 'root', 'ignorePatterns', 'globals'].includes(k));
   assert.equal(
     unexpectedKeys.length,
     0,
@@ -455,18 +396,7 @@ const WORKFLOW_FILES = [
 test('regression: no workflow uses bare pnpm install (all use --frozen-lockfile or -g flag)', () => {
   for (const file of WORKFLOW_FILES) {
     const content = readFile(file);
-    const bareInstall = content
-      .split('\n')
-      .filter(
-        (line) =>
-          /pnpm install(?! --frozen-lockfile)(?! -g)/.test(line) &&
-          !line.trimStart().startsWith('#'),
-      );
-    assert.equal(
-      bareInstall.length,
-      0,
-      `${file}: found bare pnpm install lines: ${bareInstall.join('; ')}`,
-    );
+    assertNoBarePnpmInstall(content, file);
   }
 });
 

--- a/services/api/src/tests/config.test.ts
+++ b/services/api/src/tests/config.test.ts
@@ -226,7 +226,9 @@ test('deploy-vercel-preview.yml: all install steps use --frozen-lockfile', () =>
 test('deploy-vercel-preview.yml: deploy job includes pnpm install --frozen-lockfile step', () => {
   const content = readFile('.github/workflows/deploy-vercel-preview.yml');
   // The deploy job section starts after "  deploy:" heading.
-  const deploySection = content.slice(content.indexOf('\n  deploy:'));
+  const idx = content.indexOf('\n  deploy:');
+  assert.ok(idx !== -1, 'deploy-vercel-preview.yml: could not find "  deploy:" job section in file');
+  const deploySection = content.slice(idx);
   assertContains(deploySection, 'pnpm install --frozen-lockfile', 'deploy-vercel-preview.yml deploy job install');
 });
 


### PR DESCRIPTION
### Motivation

- Make the monorepo safe for development and production deployments by centralizing env expectations, gating deploy workflows, and documenting integration contracts between bot, mini app, and API.
- Prevent accidental multi-provider or unapproved production deploys by adding deploy-provider gates and clearer CI behavior.
- Improve reviewability for operators by adding explicit docs and a canonical `.env.example` without embedding secrets.

### Description

- Centralized environment and platform expectations by expanding and standardizing `.env.example` and adding `docs/environment_matrix.md`, `docs/deployment.md`, and `docs/integration_points.md` to describe dev vs prod, public vs private vars, and API/bot/mini-app contracts.
- Hardened GitHub Actions deploy workflows by gating them on repository variables (`DEPLOY_PROVIDER`, `ENABLE_PROD_DEPLOY`, `ENABLE_PREVIEW_DEPLOY`), adding `timeout-minutes`, and standardizing `pnpm install --frozen-lockfile` usage across deploy jobs; adjusted CI to focus on deterministic checks (`typecheck`, `build`, `@stixmagic/api` tests).
- Minor repo hygiene and config updates: added `apps/web/.eslintrc.json` to make web lint config explicit, updated `.gitignore` to ignore local API runtime data, and linked the new docs from `README.md`.
- Files changed (high level): `.env.example`, `.github/workflows/*` (CI + all deploy workflows), `.gitignore`, `README.md`, `apps/web/.eslintrc.json`, `docs/deployment.md`, `docs/environment_matrix.md`, `docs/integration_points.md`.

### Testing

- `pnpm install --frozen-lockfile` — succeeded.
- `pnpm typecheck` — succeeded (monorepo TypeScript checks passed).
- `pnpm --filter @stixmagic/api test` — succeeded (API unit tests passed).
- `pnpm build` — failed in this environment due to network inability to fetch Google Fonts during the Next.js build (`ENETUNREACH` to `fonts.googleapis.com`), so full static build validation requires a network-enabled CI or self-hosted fonts.
- `pnpm lint` — initially failed because the web workspace prompted to configure ESLint and installing `eslint`/`eslint-config-next` was blocked by registry access (npm registry `403`) in this environment; `apps/web/.eslintrc.json` was added to avoid the interactive prompt but installing missing dev deps must be done where registry access is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e84d4d88832bbca5ef9dd6698dc1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deployment, environment matrix, and integration guides with deployment checklist and provider notes.

* **Chores**
  * Expanded environment template with clearer client/server guidance and additional Telegram/deploy-related entries.
  * Strengthened CI/CD workflows with job timeouts, provider gating, and stricter dependency installation.
  * Added VCS ignore entry for local runtime data and a web lint config.

* **Tests**
  * Added validation tests to assert workflow, CI/CD, and environment-template consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->