### PR TITLE
Add user-friendly API error handling and UI for Groups and GroupView

### DIFF
--- a/apps/web/app/groups/[group_id]/GroupView.tsx
+++ b/apps/web/app/groups/[group_id]/GroupView.tsx
@@ -6,26 +6,10 @@ import { Panel } from '@stixmagic/ui';
 import type { TelegramGroup, ReactionRule } from '@stixmagic/types';
 import { getGroup, getRules, isDemoModeEnabled, isApiFallbackEnabled } from '../../lib/api-client';
 import { MOCK_GROUPS, MOCK_RULES } from '../../lib/mock-data';
+import { formatApiFailureMessage } from '../../lib/format-api-error';
 
 interface Props {
   groupId: string;
-}
-
-function formatApiFailureMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : '';
-  if (message.includes('API 401')) {
-    return 'Authentication failed. Re-open the mini app from Telegram and try again.';
-  }
-  if (message.includes('API 403')) {
-    return 'Your account is not authorized to access this group.';
-  }
-  if (message.includes('API 404')) {
-    return 'This group no longer exists or you no longer have access to it.';
-  }
-  if (message.includes('API 5')) {
-    return 'The API is currently unavailable. Please retry in a moment.';
-  }
-  return 'We could not load this group from the API. Please refresh and try again.';
 }
 
 export default function GroupView({ groupId }: Props) {
@@ -47,7 +31,7 @@ export default function GroupView({ groupId }: Props) {
         const technicalMessage = error instanceof Error ? error.message : 'Unknown error';
         console.warn('[API_FAIL]', { allowFallback, message: technicalMessage });
         if (!allowFallback) {
-          setErrorMessage(formatApiFailureMessage(error));
+          setErrorMessage(formatApiFailureMessage(error, 'this group'));
           setGroup(null);
           setRules([]);
         }

--- a/apps/web/app/groups/[group_id]/GroupView.tsx
+++ b/apps/web/app/groups/[group_id]/GroupView.tsx
@@ -11,12 +11,30 @@ interface Props {
   groupId: string;
 }
 
+function formatApiFailureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  if (message.includes('API 401')) {
+    return 'Authentication failed. Re-open the mini app from Telegram and try again.';
+  }
+  if (message.includes('API 403')) {
+    return 'Your account is not authorized to access this group.';
+  }
+  if (message.includes('API 404')) {
+    return 'This group no longer exists or you no longer have access to it.';
+  }
+  if (message.includes('API 5')) {
+    return 'The API is currently unavailable. Please retry in a moment.';
+  }
+  return 'We could not load this group from the API. Please refresh and try again.';
+}
+
 export default function GroupView({ groupId }: Props) {
   const allowFallback = useMemo(() => isDemoModeEnabled() || isApiFallbackEnabled(), []);
   const fallbackGroup = allowFallback ? (MOCK_GROUPS.find((g) => g.id === groupId) ?? null) : null;
   const [group, setGroup] = useState<TelegramGroup | null>(fallbackGroup);
   const [rules, setRules] = useState<ReactionRule[]>(allowFallback ? (MOCK_RULES[groupId] ?? []) : []);
   const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     async function loadGroupData() {
@@ -24,10 +42,12 @@ export default function GroupView({ groupId }: Props) {
         const [g, r] = await Promise.all([getGroup(groupId), getRules(groupId)]);
         if (g) setGroup(g);
         setRules(r);
+        setErrorMessage(null);
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        console.warn('[API_FAIL]', { allowFallback, message });
+        const technicalMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.warn('[API_FAIL]', { allowFallback, message: technicalMessage });
         if (!allowFallback) {
+          setErrorMessage(formatApiFailureMessage(error));
           setGroup(null);
           setRules([]);
         }
@@ -38,6 +58,18 @@ export default function GroupView({ groupId }: Props) {
 
     loadGroupData();
   }, [groupId, allowFallback]);
+
+  if (!group && errorMessage) {
+    return (
+      <Panel variant="secondary">
+        <p className="text-sm font-medium text-text">Couldn&apos;t load this group.</p>
+        <p className="mt-1 text-sm text-muted">{errorMessage}</p>
+        <p className="mt-2 text-xs text-muted">
+          Check your Telegram login/session and API availability, then refresh this page.
+        </p>
+      </Panel>
+    );
+  }
 
   if (!group) {
     return (

--- a/apps/web/app/groups/page.tsx
+++ b/apps/web/app/groups/page.tsx
@@ -8,14 +8,17 @@ import { getGroups, getRules, getMiniAppBootstrap, isDemoModeEnabled, isApiFallb
 import { MOCK_GROUPS, MOCK_RULES } from '../lib/mock-data';
 
 function formatApiFailureMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : '';
-  if (message.includes('API 401')) {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const match = message.match(/API\s+(\d{3})/);
+  const statusCode = match ? Number(match[1]) : null;
+
+  if (statusCode === 401) {
     return 'Authentication failed. Re-open the mini app from Telegram and try again.';
   }
-  if (message.includes('API 403')) {
+  if (statusCode === 403) {
     return 'Your account is not authorized to access groups for this workspace.';
   }
-  if (message.includes('API 5')) {
+  if (statusCode !== null && statusCode >= 500 && statusCode < 600) {
     return 'The API is currently unavailable. Please retry in a moment.';
   }
   return 'We could not load groups from the API. Please refresh and try again.';

--- a/apps/web/app/groups/page.tsx
+++ b/apps/web/app/groups/page.tsx
@@ -7,11 +7,26 @@ import type { TelegramGroup, ReactionRule } from '@stixmagic/types';
 import { getGroups, getRules, getMiniAppBootstrap, isDemoModeEnabled, isApiFallbackEnabled } from '../lib/api-client';
 import { MOCK_GROUPS, MOCK_RULES } from '../lib/mock-data';
 
+function formatApiFailureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  if (message.includes('API 401')) {
+    return 'Authentication failed. Re-open the mini app from Telegram and try again.';
+  }
+  if (message.includes('API 403')) {
+    return 'Your account is not authorized to access groups for this workspace.';
+  }
+  if (message.includes('API 5')) {
+    return 'The API is currently unavailable. Please retry in a moment.';
+  }
+  return 'We could not load groups from the API. Please refresh and try again.';
+}
+
 export default function GroupsPage() {
   const allowFallback = useMemo(() => isDemoModeEnabled() || isApiFallbackEnabled(), []);
   const [groups, setGroups] = useState<TelegramGroup[]>(allowFallback ? MOCK_GROUPS : []);
   const [allRules, setAllRules] = useState<Record<string, ReactionRule[]>>(allowFallback ? MOCK_RULES : {});
   const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [botUrl, setBotUrl] = useState('https://t.me/StixMagicBot');
 
   useEffect(() => {
@@ -23,6 +38,7 @@ export default function GroupsPage() {
         const fetchedGroups = await getGroups();
         const adminGroups = fetchedGroups.filter((g) => g.isAdmin);
         setGroups(adminGroups);
+        setErrorMessage(null);
         const rulesMap: Record<string, ReactionRule[]> = {};
         await Promise.all(
           adminGroups.map(async (g) => {
@@ -31,9 +47,10 @@ export default function GroupsPage() {
         );
         setAllRules(rulesMap);
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        console.warn('[API_FAIL]', { allowFallback, message });
+        const technicalMessage = error instanceof Error ? error.message : 'Unknown error';
+        console.warn('[API_FAIL]', { allowFallback, message: technicalMessage });
         if (!allowFallback) {
+          setErrorMessage(formatApiFailureMessage(error));
           setGroups([]);
           setAllRules({});
         }
@@ -77,6 +94,14 @@ export default function GroupsPage() {
             </Panel>
           ))}
         </div>
+      ) : errorMessage ? (
+        <Panel variant="secondary">
+          <p className="text-sm font-medium text-text">Couldn&apos;t load groups.</p>
+          <p className="mt-1 text-sm text-muted">{errorMessage}</p>
+          <p className="mt-2 text-xs text-muted">
+            Check your sign-in/session in Telegram and confirm the API service is reachable, then refresh.
+          </p>
+        </Panel>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {groups.map((group) => {
@@ -156,4 +181,3 @@ export default function GroupsPage() {
     </div>
   );
 }
-

--- a/apps/web/app/groups/page.tsx
+++ b/apps/web/app/groups/page.tsx
@@ -6,23 +6,7 @@ import { Panel } from '@stixmagic/ui';
 import type { TelegramGroup, ReactionRule } from '@stixmagic/types';
 import { getGroups, getRules, getMiniAppBootstrap, isDemoModeEnabled, isApiFallbackEnabled } from '../lib/api-client';
 import { MOCK_GROUPS, MOCK_RULES } from '../lib/mock-data';
-
-function formatApiFailureMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error ?? '');
-  const match = message.match(/API\s+(\d{3})/);
-  const statusCode = match ? Number(match[1]) : null;
-
-  if (statusCode === 401) {
-    return 'Authentication failed. Re-open the mini app from Telegram and try again.';
-  }
-  if (statusCode === 403) {
-    return 'Your account is not authorized to access groups for this workspace.';
-  }
-  if (statusCode !== null && statusCode >= 500 && statusCode < 600) {
-    return 'The API is currently unavailable. Please retry in a moment.';
-  }
-  return 'We could not load groups from the API. Please refresh and try again.';
-}
+import { formatApiFailureMessage } from '../lib/format-api-error';
 
 export default function GroupsPage() {
   const allowFallback = useMemo(() => isDemoModeEnabled() || isApiFallbackEnabled(), []);
@@ -53,7 +37,7 @@ export default function GroupsPage() {
         const technicalMessage = error instanceof Error ? error.message : 'Unknown error';
         console.warn('[API_FAIL]', { allowFallback, message: technicalMessage });
         if (!allowFallback) {
-          setErrorMessage(formatApiFailureMessage(error));
+          setErrorMessage(formatApiFailureMessage(error, 'groups for this workspace'));
           setGroups([]);
           setAllRules({});
         }

--- a/apps/web/app/lib/format-api-error.ts
+++ b/apps/web/app/lib/format-api-error.ts
@@ -1,0 +1,19 @@
+export function formatApiFailureMessage(error: unknown, resourceLabel = 'the requested resource'): string {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const match = message.match(/API\s+(\d{3})/);
+  const statusCode = match ? Number(match[1]) : null;
+
+  if (statusCode === 401) {
+    return 'Authentication failed. Re-open the mini app from Telegram and try again.';
+  }
+  if (statusCode === 403) {
+    return `Your account is not authorized to access ${resourceLabel}.`;
+  }
+  if (statusCode === 404) {
+    return `It looks like ${resourceLabel} no longer exists or you no longer have access to it.`;
+  }
+  if (statusCode !== null && statusCode >= 500 && statusCode < 600) {
+    return 'The API is currently unavailable. Please retry in a moment.';
+  }
+  return `We could not load ${resourceLabel} from the API. Please refresh and try again.`;
+}


### PR DESCRIPTION
### Motivation
- Surface clearer, actionable messages when API calls to load groups or a single group fail so users understand next steps.
- Avoid exposing raw technical errors in the UI while still logging a technical message for diagnostics.
- Preserve demo/fallback behavior when `isDemoModeEnabled()` or `isApiFallbackEnabled()` is active.

### Description
- Introduce `formatApiFailureMessage` in `GroupsPage` and `GroupView` to map common API failure cases to friendly messages like authentication, authorization, not found, and service unavailable.
- Add `errorMessage` state and set it on API failures while clearing it on successful fetches, and keep logging a `technicalMessage` to the console for debugging.
- Render a secondary `Panel` with the user-facing error message when the API fails and no fallback data is allowed, leaving the existing "Group not found" behavior intact when appropriate.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c89d79c7e0832bbb3198b87bba5faf)