### PR TITLE
🎨 Palette: Add form labels accessibility in ReactionsEditor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve Form Label Associations
+**Learning:** Found multiple instances of forms where `label` elements were visually grouped with `input`/`textarea` elements but lacked programmatic association via the `htmlFor` and `id` attributes. This is a common accessibility issue that impairs screen reader experiences.
+**Action:** Always ensure that every form input field is explicitly tied to its `label` using `id` and `htmlFor` to enhance accessibility and standard UX.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -240,10 +240,11 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
           <div className="mt-5 space-y-5">
             {/* Rule Name */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label htmlFor="rule-name" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Rule Name
               </label>
               <input
+                id="rule-name"
                 type="text"
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -278,7 +279,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Trigger Value */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label htmlFor="trigger-value" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Value
               </label>
 
@@ -302,6 +303,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                     ))}
                   </div>
                   <input
+                    id="trigger-value"
                     type="text"
                     value={form.triggerValue}
                     onChange={(e) => setForm({ ...form, triggerValue: e.target.value })}
@@ -312,6 +314,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               ) : (
                 <>
                   <input
+                    id="trigger-value"
                     type="text"
                     value={form.triggerValue}
                     onChange={(e) => setForm({ ...form, triggerValue: e.target.value })}
@@ -352,11 +355,12 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Response Content */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label htmlFor="response-content" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Content
               </label>
               {form.responseType === 'message' ? (
                 <textarea
+                  id="response-content"
                   value={form.responseContent}
                   onChange={(e) => setForm({ ...form, responseContent: e.target.value })}
                   placeholder={RESPONSE_PLACEHOLDER.message}
@@ -365,6 +369,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 />
               ) : (
                 <input
+                  id="response-content"
                   type="text"
                   value={form.responseContent}
                   onChange={(e) => setForm({ ...form, responseContent: e.target.value })}


### PR DESCRIPTION
💡 What: Added missing `htmlFor` and `id` tags in `ReactionsEditor.tsx` form.
🎯 Why: Forms must have proper programmatic labels to be accessible and usable.
♿ Accessibility: Improved form usage for screen readers by associating `label` and `input` fields.

---
*PR created automatically by Jules for task [6458674390802905856](https://jules.google.com/task/6458674390802905856) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form accessibility by properly associating labels with their corresponding input fields for improved support with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->