### PR TITLE
🎨 Palette: Enhance Accessibility in ReactionsEditor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-15 - Accessible Tabs Pattern
 **Learning:** The custom `Tabs` component lacked ARIA roles and keyboard focus styles, making it difficult for screen reader users and keyboard navigators to understand its state. Adding `role="tablist"`, `role="tab"`, `role="tabpanel"`, and proper `aria-controls`/`aria-labelledby` linkages is an essential pattern for custom interactive components in this design system.
 **Action:** Always check custom interactive components like tabs or dialogs for proper ARIA roles and relationships, and ensure `focus-visible` styles are present for keyboard accessibility.
+
+## 2024-05-17 - Radio Group Accessibility
+**Learning:** Custom interactive elements that act as radio buttons (like the Trigger Type and Response Type grids in `ReactionsEditor`) need `role="radiogroup"` on the container and `role="radio"` with `aria-checked` on the options. Without these, screen readers treat them as separate buttons without a semantic group relationship. Note: True WCAG compliance for radiogroups expects arrow-key navigation rather than just `Tab`.
+**Action:** When converting lists of options into custom radio-like selections, always apply `role="radiogroup"`, `role="radio"`, and `aria-checked` attributes to provide context to assistive technologies.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type KeyboardEvent } from 'react';
 import Link from 'next/link';
 import type { ReactionRule, TriggerType, ResponseType } from '@stixmagic/types';
 import { Panel } from '@stixmagic/ui';
@@ -119,6 +119,44 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
   const setResponseType = (responseType: ResponseType) =>
     setForm((prev) => ({ ...prev, responseType, responseContent: '' }));
+
+  const handleRadioGroupKeyDown = <T extends string>(
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+    options: { value: T }[],
+    setValue: (value: T) => void,
+    idPrefix: string
+  ) => {
+    const { key } = event;
+    const lastIndex = options.length - 1;
+    let nextIndex: number | null = null;
+
+    if (key === 'ArrowRight' || key === 'ArrowDown') {
+      event.preventDefault();
+      nextIndex = index === lastIndex ? 0 : index + 1;
+    } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
+      event.preventDefault();
+      nextIndex = index === 0 ? lastIndex : index - 1;
+    } else if (key === 'Home') {
+      event.preventDefault();
+      nextIndex = 0;
+    } else if (key === 'End') {
+      event.preventDefault();
+      nextIndex = lastIndex;
+    } else if (key === ' ' || key === 'Enter') {
+      event.preventDefault();
+      setValue(options[index].value);
+      return;
+    }
+
+    if (nextIndex === null) return;
+
+    const nextOption = options[nextIndex];
+    setValue(nextOption.value);
+    requestAnimationFrame(() => {
+      document.getElementById(`${idPrefix}-${nextOption.value}`)?.focus();
+    });
+  };
 
   const handleToggle = async (id: string, current: boolean) => {
     const previousRules = rules;
@@ -255,16 +293,22 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Trigger Type */}
             <div>
-              <label id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <p id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Type
-              </label>
+              </p>
               <div role="radiogroup" aria-labelledby="trigger-type-label" className="mt-2 grid grid-cols-2 gap-3">
-                {TRIGGER_OPTIONS.map((opt) => (
+                {TRIGGER_OPTIONS.map((opt, index) => (
                   <button
                     key={opt.value}
+                    id={`trigger-type-${opt.value}`}
+                    type="button"
                     role="radio"
                     aria-checked={form.triggerType === opt.value}
+                    tabIndex={form.triggerType === opt.value ? 0 : -1}
                     onClick={() => setTriggerType(opt.value)}
+                    onKeyDown={(event) =>
+                      handleRadioGroupKeyDown(event, index, TRIGGER_OPTIONS, setTriggerType, 'trigger-type')
+                    }
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
@@ -333,16 +377,22 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Response Type */}
             <div>
-              <label id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <p id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Type
-              </label>
+              </p>
               <div role="radiogroup" aria-labelledby="response-type-label" className="mt-2 grid grid-cols-2 gap-3">
-                {RESPONSE_OPTIONS.map((opt) => (
+                {RESPONSE_OPTIONS.map((opt, index) => (
                   <button
                     key={opt.value}
+                    id={`response-type-${opt.value}`}
+                    type="button"
                     role="radio"
                     aria-checked={form.responseType === opt.value}
+                    tabIndex={form.responseType === opt.value ? 0 : -1}
                     onClick={() => setResponseType(opt.value)}
+                    onKeyDown={(event) =>
+                      handleRadioGroupKeyDown(event, index, RESPONSE_OPTIONS, setResponseType, 'response-type')
+                    }
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'
@@ -536,4 +586,3 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
     </div>
   );
 }
-

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -255,15 +255,17 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Trigger Type */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Type
               </label>
-              <div className="mt-2 grid grid-cols-2 gap-3">
+              <div role="radiogroup" aria-labelledby="trigger-type-label" className="mt-2 grid grid-cols-2 gap-3">
                 {TRIGGER_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
+                    role="radio"
+                    aria-checked={form.triggerType === opt.value}
                     onClick={() => setTriggerType(opt.value)}
-                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition ${
+                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'
@@ -331,15 +333,17 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Response Type */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Type
               </label>
-              <div className="mt-2 grid grid-cols-2 gap-3">
+              <div role="radiogroup" aria-labelledby="response-type-label" className="mt-2 grid grid-cols-2 gap-3">
                 {RESPONSE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
+                    role="radio"
+                    aria-checked={form.responseType === opt.value}
                     onClick={() => setResponseType(opt.value)}
-                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition ${
+                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'
@@ -499,14 +503,16 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => handleSimulate(rule)}
+                    aria-label={`Simulate rule ${rule.name}`}
                     title="Simulates the rule locally — connect a backend to fire it in Telegram"
-                    className="rounded-lg border border-accent-cyan/20 px-3 py-1.5 text-xs font-medium text-accent-cyan transition hover:border-accent-cyan/40 hover:bg-accent-cyan/5"
+                    className="rounded-lg border border-accent-cyan/20 px-3 py-1.5 text-xs font-medium text-accent-cyan transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/50 hover:border-accent-cyan/40 hover:bg-accent-cyan/5"
                   >
                     Simulate
                   </button>
                   <button
                     onClick={() => handleToggle(rule.id, rule.enabled)}
-                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
+                    aria-label={`${rule.enabled ? 'Pause' : 'Enable'} rule ${rule.name}`}
+                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal/50 ${
                       rule.enabled
                         ? 'border-muted/20 text-muted hover:border-muted/40 hover:text-text'
                         : 'border-accent-teal/20 text-accent-teal hover:border-accent-teal/40 hover:bg-accent-teal/5'
@@ -516,7 +522,8 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   </button>
                   <button
                     onClick={() => handleDelete(rule.id)}
-                    className="rounded-lg border border-accent-pink/20 px-3 py-1.5 text-xs font-medium text-accent-pink transition hover:border-accent-pink/40 hover:bg-accent-pink/5"
+                    aria-label={`Delete rule ${rule.name}`}
+                    className="rounded-lg border border-accent-pink/20 px-3 py-1.5 text-xs font-medium text-accent-pink transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-pink/50 hover:border-accent-pink/40 hover:bg-accent-pink/5"
                   >
                     Delete
                   </button>

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type KeyboardEvent } from 'react';
 import Link from 'next/link';
 import type { ReactionRule, TriggerType, ResponseType } from '@stixmagic/types';
 import { Panel } from '@stixmagic/ui';
@@ -57,6 +57,33 @@ const RESPONSE_HINT: Partial<Record<ResponseType, string>> = {
     'To get a sticker file ID: forward the sticker to @userinfobot or use the /sticker command with your Stix Magic bot.',
   animation:
     'To get a GIF file ID: send the animation in a chat with your Stix Magic bot, which will reply with the file ID.'
+};
+
+const handleRadioGroupKeyDown = <T extends TriggerType | ResponseType>(
+  event: KeyboardEvent<HTMLDivElement>,
+  options: ReadonlyArray<{ value: T }>,
+  currentValue: T,
+  setValue: (value: T) => void
+) => {
+  const currentIndex = options.findIndex((opt) => opt.value === currentValue);
+  if (currentIndex === -1) return;
+
+  let nextIndex: number | null = null;
+  if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+    nextIndex = (currentIndex + 1) % options.length;
+  } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+    nextIndex = (currentIndex - 1 + options.length) % options.length;
+  } else if (event.key === 'Home') {
+    nextIndex = 0;
+  } else if (event.key === 'End') {
+    nextIndex = options.length - 1;
+  }
+
+  if (nextIndex === null) return;
+
+  event.preventDefault();
+  setValue(options[nextIndex].value);
+  event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]')[nextIndex]?.focus();
 };
 
 /**
@@ -258,12 +285,18 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               <label id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Type
               </label>
-              <div role="radiogroup" aria-labelledby="trigger-type-label" className="mt-2 grid grid-cols-2 gap-3">
+              <div
+                role="radiogroup"
+                aria-labelledby="trigger-type-label"
+                onKeyDown={(e) => handleRadioGroupKeyDown(e, TRIGGER_OPTIONS, form.triggerType, setTriggerType)}
+                className="mt-2 grid grid-cols-2 gap-3"
+              >
                 {TRIGGER_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
                     role="radio"
                     aria-checked={form.triggerType === opt.value}
+                    tabIndex={form.triggerType === opt.value ? 0 : -1}
                     onClick={() => setTriggerType(opt.value)}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
@@ -336,12 +369,18 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               <label id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Type
               </label>
-              <div role="radiogroup" aria-labelledby="response-type-label" className="mt-2 grid grid-cols-2 gap-3">
+              <div
+                role="radiogroup"
+                aria-labelledby="response-type-label"
+                onKeyDown={(e) => handleRadioGroupKeyDown(e, RESPONSE_OPTIONS, form.responseType, setResponseType)}
+                className="mt-2 grid grid-cols-2 gap-3"
+              >
                 {RESPONSE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
                     role="radio"
                     aria-checked={form.responseType === opt.value}
+                    tabIndex={form.responseType === opt.value ? 0 : -1}
                     onClick={() => setResponseType(opt.value)}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, type KeyboardEvent } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import type { ReactionRule, TriggerType, ResponseType } from '@stixmagic/types';
 import { Panel } from '@stixmagic/ui';
@@ -119,44 +119,6 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
   const setResponseType = (responseType: ResponseType) =>
     setForm((prev) => ({ ...prev, responseType, responseContent: '' }));
-
-  const handleRadioGroupKeyDown = <T extends string>(
-    event: KeyboardEvent<HTMLButtonElement>,
-    index: number,
-    options: { value: T }[],
-    setValue: (value: T) => void,
-    idPrefix: string
-  ) => {
-    const { key } = event;
-    const lastIndex = options.length - 1;
-    let nextIndex: number | null = null;
-
-    if (key === 'ArrowRight' || key === 'ArrowDown') {
-      event.preventDefault();
-      nextIndex = index === lastIndex ? 0 : index + 1;
-    } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
-      event.preventDefault();
-      nextIndex = index === 0 ? lastIndex : index - 1;
-    } else if (key === 'Home') {
-      event.preventDefault();
-      nextIndex = 0;
-    } else if (key === 'End') {
-      event.preventDefault();
-      nextIndex = lastIndex;
-    } else if (key === ' ' || key === 'Enter') {
-      event.preventDefault();
-      setValue(options[index].value);
-      return;
-    }
-
-    if (nextIndex === null) return;
-
-    const nextOption = options[nextIndex];
-    setValue(nextOption.value);
-    requestAnimationFrame(() => {
-      document.getElementById(`${idPrefix}-${nextOption.value}`)?.focus();
-    });
-  };
 
   const handleToggle = async (id: string, current: boolean) => {
     const previousRules = rules;
@@ -293,22 +255,16 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Trigger Type */}
             <div>
-              <p id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Type
-              </p>
+              </label>
               <div role="radiogroup" aria-labelledby="trigger-type-label" className="mt-2 grid grid-cols-2 gap-3">
-                {TRIGGER_OPTIONS.map((opt, index) => (
+                {TRIGGER_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
-                    id={`trigger-type-${opt.value}`}
-                    type="button"
                     role="radio"
                     aria-checked={form.triggerType === opt.value}
-                    tabIndex={form.triggerType === opt.value ? 0 : -1}
                     onClick={() => setTriggerType(opt.value)}
-                    onKeyDown={(event) =>
-                      handleRadioGroupKeyDown(event, index, TRIGGER_OPTIONS, setTriggerType, 'trigger-type')
-                    }
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
@@ -377,22 +333,16 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Response Type */}
             <div>
-              <p id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <label id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Type
-              </p>
+              </label>
               <div role="radiogroup" aria-labelledby="response-type-label" className="mt-2 grid grid-cols-2 gap-3">
-                {RESPONSE_OPTIONS.map((opt, index) => (
+                {RESPONSE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
-                    id={`response-type-${opt.value}`}
-                    type="button"
                     role="radio"
                     aria-checked={form.responseType === opt.value}
-                    tabIndex={form.responseType === opt.value ? 0 : -1}
                     onClick={() => setResponseType(opt.value)}
-                    onKeyDown={(event) =>
-                      handleRadioGroupKeyDown(event, index, RESPONSE_OPTIONS, setResponseType, 'response-type')
-                    }
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'


### PR DESCRIPTION
This PR implements accessibility enhancements in the `ReactionsEditor` component as part of Palette's mission to improve UX.

*   Added `role="radiogroup"` and `aria-labelledby` to the Trigger Type and Response Type selection grids to provide context to assistive technologies.
*   Added `role="radio"` and `aria-checked` to the option buttons within those grids.
*   Added specific `aria-label`s to the Simulate, Toggle (Pause/Enable), and Delete buttons so screen readers announce the rule's name (e.g., "Delete rule Magic Activation").
*   Added `focus-visible` styles to these elements to improve keyboard navigation visibility.

---
*PR created automatically by Jules for task [894062668541663657](https://jules.google.com/task/894062668541663657) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Trigger Type and Response Type controls now support full keyboard navigation, selection, and clearer focus indicators.
  * Rule action buttons (Simulate, Enable/Pause, Delete) have improved accessible labels and focus styling for keyboard users.

* **Documentation**
  * Added guidance on accessible patterns for custom radio-like controls and group semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only accessibility changes; main behavioral change is new arrow-key/Home/End navigation within the trigger/response option grids.
> 
> **Overview**
> Improves `ReactionsEditor` accessibility by converting the Trigger/Response type option grids into proper `radiogroup`/`radio` controls with `aria-labelledby`, `aria-checked`, and roving `tabIndex`, plus arrow-key/Home/End selection support.
> 
> Adds clearer screen-reader labels and visible keyboard focus rings for the rule action buttons (`Simulate`, `Enable/Pause`, `Delete`), and documents the radiogroup accessibility pattern in `.Jules/palette.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84138769d7a19fe93b4a964eaf5b5ff3d30a9088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->