### PR TITLE
🎨 Palette: Add confirmation dialog for delete action

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-15 - Accessible Tabs Pattern
 **Learning:** The custom `Tabs` component lacked ARIA roles and keyboard focus styles, making it difficult for screen reader users and keyboard navigators to understand its state. Adding `role="tablist"`, `role="tab"`, `role="tabpanel"`, and proper `aria-controls`/`aria-labelledby` linkages is an essential pattern for custom interactive components in this design system.
 **Action:** Always check custom interactive components like tabs or dialogs for proper ARIA roles and relationships, and ensure `focus-visible` styles are present for keyboard accessibility.
+## 2026-04-18 - Confirmation Dialog for Destructive Actions
+**Learning:** Destructive actions like deleting resources (e.g., reaction rules) must have a confirmation step to prevent accidental data loss. This improves user experience by giving a chance to recover from an accidental click.
+**Action:** Use native `window.confirm` or custom dialog components to confirm actions before performing API calls to delete data.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -133,6 +133,9 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   };
 
   const handleDelete = async (id: string) => {
+    if (!window.confirm('Are you sure you want to delete this reaction rule?')) {
+      return;
+    }
     const previousRules = rules;
     setRules((prev) => prev.filter((r) => r.id !== id));
     try {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start -p 3000",
     "typecheck": "tsc --noEmit",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --max-warnings=0 --ignore-pattern .next --ignore-pattern dist"
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --max-warnings=0 --ignore-pattern .next --ignore-pattern dist --ignore-pattern out"
   },
   "dependencies": {
     "@stixmagic/types": "workspace:*",


### PR DESCRIPTION
Adds a confirmation step before executing the deletion of a reaction rule to improve UX by preventing accidental data loss. Also logs the learning to the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [17025387483754400499](https://jules.google.com/task/17025387483754400499) started by @FriskyDevelopments*