### PR TITLE
🎨 Palette: Add keyboard focus states to custom buttons in Reactions Editor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,6 +4,3 @@
 ## 2026-04-18 - Confirmation Dialog for Destructive Actions
 **Learning:** Destructive actions like deleting resources (e.g., reaction rules) must have a confirmation step to prevent accidental data loss. This improves user experience by giving a chance to recover from an accidental click.
 **Action:** Use native `window.confirm` or custom dialog components to confirm actions before performing API calls to delete data.
-## 2024-04-21 - Custom Selection Buttons Focus Styles
-**Learning:** Custom selection buttons (like those replacing native radio buttons or selects for visual appeal) often lack proper keyboard focus states, making it difficult for keyboard users to know which option is currently focused.
-**Action:** Always add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` to interactive elements like custom cards/buttons to ensure keyboard accessibility.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-04-18 - Confirmation Dialog for Destructive Actions
 **Learning:** Destructive actions like deleting resources (e.g., reaction rules) must have a confirmation step to prevent accidental data loss. This improves user experience by giving a chance to recover from an accidental click.
 **Action:** Use native `window.confirm` or custom dialog components to confirm actions before performing API calls to delete data.
+## 2024-04-21 - Custom Selection Buttons Focus Styles
+**Learning:** Custom selection buttons (like those replacing native radio buttons or selects for visual appeal) often lack proper keyboard focus states, making it difficult for keyboard users to know which option is currently focused.
+**Action:** Always add `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` to interactive elements like custom cards/buttons to ensure keyboard accessibility.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -60,18 +60,13 @@ const RESPONSE_HINT: Partial<Record<ResponseType, string>> = {
 };
 
 /**
- * Render an interactive editor for creating, listing, and managing reaction rules for a group.
+ * Interactive React component that provides a UI to create, list, simulate, enable/disable, and delete reaction rules for a group.
  *
- * The component loads rules for `groupId`, shows a form to create new rules, and displays existing
- * rules with controls to simulate, enable/disable, and delete them.
+ * Loads rules for the provided `groupId`, performs optimistic UI updates for toggle and delete mutations, and performs local-only simulations (no backend call).
  *
- * Notes:
- * - Toggling and deleting rules update the UI optimistically and persist changes via API calls.
- * - Simulation is local-only and does not call the backend.
- *
- * @param groupId - The identifier of the group whose reaction rules are managed
- * @param groupName - The display name of the group used in UI labels and messages
- * @returns The React element that provides the ReactionsEditor UI for the specified group
+ * @param groupId - Identifier of the group whose reaction rules are managed
+ * @param groupName - Display name of the group used in UI labels and messages
+ * @returns The ReactionsEditor React element for the specified group
  */
 export default function ReactionsEditor({ groupId, groupName }: Props) {
   const [rules, setRules] = useState<ReactionRule[]>([]);

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -271,7 +271,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'
-                    }`}
+                    } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50`}
                   >
                     <span className="text-xl">{opt.icon}</span>
                     <span className="text-sm font-medium text-text">{opt.label}</span>
@@ -301,7 +301,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                         aria-pressed={form.triggerValue === emoji}
                         className={`rounded-lg px-2 py-1 text-lg transition hover:bg-accent-primary/20 ${
                           form.triggerValue === emoji ? 'bg-accent-primary/30 ring-1 ring-accent-primary/50' : ''
-                        }`}
+                        } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50`}
                         title={emoji}
                       >
                         {emoji}
@@ -350,7 +350,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'
-                    }`}
+                    } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50`}
                   >
                     <span className="text-xl">{opt.icon}</span>
                     <span className="text-sm font-medium text-text">{opt.label}</span>


### PR DESCRIPTION
Added `focus-visible` styling with accessible ring colors to the custom trigger type buttons, emoji selection buttons, and response type buttons in the ReactionsEditor component. This greatly improves the keyboard navigation and accessibility of the component.

---
*PR created automatically by Jules for task [16752044354582535205](https://jules.google.com/task/16752044354582535205) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved keyboard focus visibility on custom selection buttons with enhanced visual indicators for keyboard navigation in the reactions editor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->