### PR TITLE
🎨 Palette: Accessibility enhancements for MaskCard and GeneratorScaffold

### DIFF
--- a/packages/ui/src/components/GeneratorScaffold.tsx
+++ b/packages/ui/src/components/GeneratorScaffold.tsx
@@ -24,8 +24,10 @@ export const GeneratorScaffold = ({ steps }: GeneratorScaffoldProps) => {
           <button
             key={step.id}
             onClick={() => !step.comingSoon && setActiveStep(step.id)}
+            disabled={step.comingSoon}
+            aria-current={step.id === activeStep ? 'step' : undefined}
             className={cn(
-              'flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition',
+              'flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
               step.id === activeStep
                 ? 'border-accent-primary bg-accent-primary/10 text-text'
                 : step.comingSoon

--- a/packages/ui/src/components/MaskCard.tsx
+++ b/packages/ui/src/components/MaskCard.tsx
@@ -15,8 +15,9 @@ export const MaskCard = ({ mask, selected, onSelect }: MaskCardProps) => (
     whileHover={{ y: -4 }}
     whileTap={{ scale: 0.99 }}
     onClick={() => onSelect(mask)}
+    aria-pressed={selected}
     className={cn(
-      'rounded-2xl border p-4 text-left transition',
+      'rounded-2xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/50',
       selected
         ? 'border-accent-cyan bg-panel shadow-[0_0_32px_rgba(124,242,255,0.18)]'
         : 'border-white/10 bg-panel-secondary hover:border-white/30'


### PR DESCRIPTION
🎨 Palette: Accessibility enhancements for MaskCard and GeneratorScaffold

💡 What: Added `aria-pressed`, `aria-current`, `disabled` attributes, and `focus-visible` styles to `MaskCard` and `GeneratorScaffold`.
🎯 Why: To improve accessibility for screen readers and keyboard users, indicating toggle states, current steps, disabled steps, and focus indicators.
♿ Accessibility:
- Added `aria-pressed={selected}` to `MaskCard` to indicate toggle state to screen readers.
- Added `focus-visible` styling to both `MaskCard` and `GeneratorScaffold` buttons for keyboard navigation.
- Added `disabled={step.comingSoon}` to correctly disable "coming soon" steps in `GeneratorScaffold`.
- Added `aria-current="step"` to the active step in `GeneratorScaffold`.

---
*PR created automatically by Jules for task [9510409009379419707](https://jules.google.com/task/9510409009379419707) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds ARIA attributes and focus-visible ring styling, plus properly disables "coming soon" step buttons, with minimal impact on behavior beyond preventing clicks on disabled steps.
> 
> **Overview**
> Improves keyboard and screen-reader accessibility for `GeneratorScaffold` and `MaskCard`.
> 
> `GeneratorScaffold` now **disables** "coming soon" step buttons and marks the active step via `aria-current="step"`, and both components add **focus-visible ring** styling; `MaskCard` also exposes selection state via `aria-pressed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac8ab2b02e23d5c3075aa3c24e6d5091dd8a863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->