### PR TITLE
🎨 Palette: Add focus-visible states to ReactionsEditor buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-04-18 - Confirmation Dialog for Destructive Actions
 **Learning:** Destructive actions like deleting resources (e.g., reaction rules) must have a confirmation step to prevent accidental data loss. This improves user experience by giving a chance to recover from an accidental click.
 **Action:** Use native `window.confirm` or custom dialog components to confirm actions before performing API calls to delete data.
+## 2024-12-07 - Interactive Editor Focus States
+**Learning:** Dynamic, app-like editors with custom-styled buttons often lose visible focus states entirely when using Tailwind defaults (like `focus:outline-none`). This makes keyboard navigation nearly impossible for power users or those relying on accessibility tools, as they can't tell which action is currently selected.
+**Action:** When building interactive editor UIs with multiple action buttons, always explicitly add `focus-visible:outline-none focus-visible:ring-2` to buttons. Use context-aware ring colors (e.g., `focus-visible:ring-accent-[color]/50`) to match the button's intended styling or severity (like cyan for simulate, teal for toggle, pink for delete).

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -209,7 +209,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               setShowForm(true);
               setForm(EMPTY_FORM);
             }}
-            className="rounded-lg bg-accent-primary/20 px-5 py-2.5 text-sm font-medium text-accent-indigo transition hover:bg-accent-primary/35"
+            className="rounded-lg bg-accent-primary/20 px-5 py-2.5 text-sm font-medium text-accent-indigo transition hover:bg-accent-primary/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
           >
             + New Rule
           </button>
@@ -299,7 +299,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                         onClick={() => setForm({ ...form, triggerValue: emoji })}
                         aria-label={`Select emoji ${emoji}`}
                         aria-pressed={form.triggerValue === emoji}
-                        className={`rounded-lg px-2 py-1 text-lg transition hover:bg-accent-primary/20 ${
+                        className={`rounded-lg px-2 py-1 text-lg transition hover:bg-accent-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                           form.triggerValue === emoji ? 'bg-accent-primary/30 ring-1 ring-accent-primary/50' : ''
                         }`}
                         title={emoji}
@@ -417,7 +417,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   !form.triggerValue.trim() ||
                   !form.responseContent.trim()
                 }
-                className="rounded-lg bg-accent-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-accent-indigo disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-lg bg-accent-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-accent-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {saving ? 'Saving…' : 'Save Rule'}
               </button>
@@ -426,7 +426,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   setShowForm(false);
                   setForm(EMPTY_FORM);
                 }}
-                className="rounded-lg border border-accent-primary/20 px-5 py-2 text-sm font-medium text-muted transition hover:border-accent-primary/40 hover:text-text"
+                className="rounded-lg border border-accent-primary/20 px-5 py-2 text-sm font-medium text-muted transition hover:border-accent-primary/40 hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
               >
                 Cancel
               </button>
@@ -459,7 +459,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
             </p>
             <button
               onClick={() => setShowForm(true)}
-              className="mt-4 rounded-lg bg-accent-primary/20 px-5 py-2 text-sm font-medium text-accent-indigo transition hover:bg-accent-primary/35"
+              className="mt-4 rounded-lg bg-accent-primary/20 px-5 py-2 text-sm font-medium text-accent-indigo transition hover:bg-accent-primary/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
             >
               + Create First Rule
             </button>
@@ -508,14 +508,14 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                     onClick={() => handleSimulate(rule)}
                     aria-label={`Simulate rule ${rule.name}`}
                     title="Simulates the rule locally — connect a backend to fire it in Telegram"
-                    className="rounded-lg border border-accent-cyan/20 px-3 py-1.5 text-xs font-medium text-accent-cyan transition hover:border-accent-cyan/40 hover:bg-accent-cyan/5"
+                    className="rounded-lg border border-accent-cyan/20 px-3 py-1.5 text-xs font-medium text-accent-cyan transition hover:border-accent-cyan/40 hover:bg-accent-cyan/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/50"
                   >
                     Simulate
                   </button>
                   <button
                     onClick={() => handleToggle(rule.id, rule.enabled)}
                     aria-label={`${rule.enabled ? 'Pause' : 'Enable'} rule ${rule.name}`}
-                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
+                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal/50 ${
                       rule.enabled
                         ? 'border-muted/20 text-muted hover:border-muted/40 hover:text-text'
                         : 'border-accent-teal/20 text-accent-teal hover:border-accent-teal/40 hover:bg-accent-teal/5'
@@ -526,7 +526,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   <button
                     onClick={() => handleDelete(rule.id)}
                     aria-label={`Delete rule ${rule.name}`}
-                    className="rounded-lg border border-accent-pink/20 px-3 py-1.5 text-xs font-medium text-accent-pink transition hover:border-accent-pink/40 hover:bg-accent-pink/5"
+                    className="rounded-lg border border-accent-pink/20 px-3 py-1.5 text-xs font-medium text-accent-pink transition hover:border-accent-pink/40 hover:bg-accent-pink/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-pink/50"
                   >
                     Delete
                   </button>

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -346,7 +346,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                     key={opt.value}
                     onClick={() => setResponseType(opt.value)}
                     aria-pressed={form.responseType === opt.value}
-                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
+                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'
@@ -515,10 +515,10 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   <button
                     onClick={() => handleToggle(rule.id, rule.enabled)}
                     aria-label={`${rule.enabled ? 'Pause' : 'Enable'} rule ${rule.name}`}
-                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal/50 ${
+                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 ${
                       rule.enabled
-                        ? 'border-muted/20 text-muted hover:border-muted/40 hover:text-text'
-                        : 'border-accent-teal/20 text-accent-teal hover:border-accent-teal/40 hover:bg-accent-teal/5'
+                        ? 'border-muted/20 text-muted hover:border-muted/40 hover:text-text focus-visible:ring-muted/50'
+                        : 'border-accent-teal/20 text-accent-teal hover:border-accent-teal/40 hover:bg-accent-teal/5 focus-visible:ring-accent-teal/50'
                     }`}
                   >
                     {rule.enabled ? 'Pause' : 'Enable'}

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -267,7 +267,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                     key={opt.value}
                     onClick={() => setTriggerType(opt.value)}
                     aria-pressed={form.triggerType === opt.value}
-                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition ${
+                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'
@@ -346,7 +346,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                     key={opt.value}
                     onClick={() => setResponseType(opt.value)}
                     aria-pressed={form.responseType === opt.value}
-                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition ${
+                    className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'
                         : 'border-accent-primary/10 bg-background/40 hover:border-accent-primary/30'


### PR DESCRIPTION
💡 What: Added explicit `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-[color]/50` to interactive buttons in `ReactionsEditor.tsx`.
🎯 Why: Tailwind's default or custom styles often lose visible focus indicators, making keyboard navigation difficult. This change ensures users relying on keyboards or accessibility tools can see exactly which element is focused.
♿ Accessibility: Enhanced keyboard navigation and focus states.

---
*PR created automatically by Jules for task [12521669720302324186](https://jules.google.com/task/12521669720302324186) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change to improve keyboard focus visibility; no business logic or API behavior is modified.
> 
> **Overview**
> Improves keyboard accessibility in `ReactionsEditor.tsx` by adding explicit `focus-visible` ring styles to all interactive buttons (create/save/cancel, trigger/response selectors, emoji picker, and rule actions like simulate/toggle/delete).
> 
> Updates `.Jules/palette.md` with a new design-system note documenting the focus-visible pattern and recommended ring colors for editor-style UIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b123613a0522498d157c0c45cc18127184c22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Strengthened keyboard navigation support with improved visual focus indicators throughout the reactions editor, making it easier for keyboard-only users to navigate and identify active controls.

* **Documentation**
  * Added comprehensive design guidance on implementing keyboard accessibility best practices for interactive user interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->