### PR TITLE
🎨 Palette: Add focus-visible styles to navigation and CTA links

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -25,20 +25,20 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           </div>
           <header className="sticky top-0 z-20 border-b border-accent-primary/15 bg-background/70 backdrop-blur-md">
             <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
-              <Link href="/" className="inline-flex items-center gap-2">
+              <Link href="/" className="inline-flex items-center gap-2 rounded transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">
                 <span className="text-xl drop-shadow-[0_0_10px_rgba(0,212,255,0.6)]">🪄</span>
                 <span className="bg-gradient-to-r from-accent-cyan via-accent-indigo to-accent-violet bg-clip-text text-lg font-extrabold tracking-[0.08em] text-transparent">
                   MagicStix
                 </span>
               </Link>
               <nav className="flex items-center gap-6 text-sm text-muted">
-                <Link href="/" className="transition hover:text-text">Home</Link>
-                <Link href="/ecosystem" className="transition hover:text-text">Ecosystem</Link>
-                <Link href="/packs" className="transition hover:text-text">Packs</Link>
-                <Link href="/gallery" className="transition hover:text-text">Gallery</Link>
-                <Link href="/generator" className="transition hover:text-text">Generator</Link>
-                <Link href="/masks" className="transition hover:text-text">Masks</Link>
-                <Link href="/dashboard" className="transition hover:text-text">Dashboard</Link>
+                <Link href="/" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Home</Link>
+                <Link href="/ecosystem" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Ecosystem</Link>
+                <Link href="/packs" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Packs</Link>
+                <Link href="/gallery" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Gallery</Link>
+                <Link href="/generator" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Generator</Link>
+                <Link href="/masks" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Masks</Link>
+                <Link href="/dashboard" className="rounded transition hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50">Dashboard</Link>
               </nav>
             </div>
           </header>

--- a/packages/ui/src/components/CTASection.tsx
+++ b/packages/ui/src/components/CTASection.tsx
@@ -26,13 +26,13 @@ export const CTASection = () => (
       <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
         <Link
           href="/masks"
-          className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)]"
+          className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
         >
           Explore Masks
         </Link>
         <a
           href="https://github.com/FriskyDevelopments/stixmagic-web"
-          className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan"
+          className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/50"
         >
           Follow the Build
         </a>

--- a/packages/ui/src/components/Hero.tsx
+++ b/packages/ui/src/components/Hero.tsx
@@ -59,13 +59,13 @@ export const Hero = ({
         <div className="mt-8 flex flex-wrap gap-3">
           <Link
             href={primaryHref}
-            className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)]"
+            className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
           >
             {primaryCta}
           </Link>
           <Link
             href={secondaryHref}
-            className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan"
+            className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/50"
           >
             {secondaryCta}
           </Link>


### PR DESCRIPTION
💡 **What:** Added `focus-visible` styles (`outline-none ring-2 ring-accent-primary/50` or `ring-accent-cyan/50`) to header navigation links and major Call-To-Action buttons across the site.
🎯 **Why:** To improve keyboard accessibility. Previously, these links lacked clear visual indicators when focused via keyboard navigation, making the site difficult to navigate for users relying on keyboard input.
📸 **Before/After:** See the attached visual verification for a demonstration of the new focus rings on the header links.
♿ **Accessibility:** This directly improves WCAG compliance for focus visibility (Criterion 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [4231716632071194680](https://jules.google.com/task/4231716632071194680) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only styling changes that improve keyboard focus visibility. Main risk is minor UI regressions (unexpected focus ring appearance or layout/overflow issues) across affected links.
> 
> **Overview**
> Improves keyboard accessibility by adding `focus-visible` ring styling to the header brand link and all primary navigation links in `apps/web/app/layout.tsx`.
> 
> Adds matching `focus-visible` styles to the main CTA links/buttons in `CTASection` and `Hero` (including the external GitHub link), making focus state consistently visible across key entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17820b941e1c8c6b44617f26e9591775fea6bb51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->