### PR TITLE
🎨 Palette: Add keyboard focus states to Hero and CTA links

### DIFF
--- a/packages/ui/src/components/CTASection.tsx
+++ b/packages/ui/src/components/CTASection.tsx
@@ -26,13 +26,13 @@ export const CTASection = () => (
       <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
         <Link
           href="/masks"
-          className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)]"
+          className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
         >
           Explore Masks
         </Link>
         <a
           href="https://github.com/FriskyDevelopments/stixmagic-web"
-          className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan"
+          className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
         >
           Follow the Build
         </a>

--- a/packages/ui/src/components/Hero.tsx
+++ b/packages/ui/src/components/Hero.tsx
@@ -59,13 +59,13 @@ export const Hero = ({
         <div className="mt-8 flex flex-wrap gap-3">
           <Link
             href={primaryHref}
-            className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)]"
+            className="rounded-xl bg-gradient-to-r from-accent-primary via-accent-indigo to-accent-violet px-5 py-3 text-sm font-semibold text-white shadow-[0_4px_24px_rgba(99,102,241,0.45)] transition hover:translate-y-[-1px] hover:shadow-[0_8px_36px_rgba(168,85,247,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
           >
             {primaryCta}
           </Link>
           <Link
             href={secondaryHref}
-            className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan"
+            className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
           >
             {secondaryCta}
           </Link>


### PR DESCRIPTION
🎨 **Palette UX Improvement: Keyboard Focus States**

💡 **What:** Added `focus-visible` ring styling to the primary navigational links within the `Hero` and `CTASection` components.
🎯 **Why:** To improve keyboard accessibility. Previously, these stylized link "buttons" lacked an explicit visual focus state, making it difficult for keyboard-only or screen reader users to identify when these primary calls-to-action were focused.
♿ **Accessibility:** This directly addresses the learning from the Palette journal regarding consistent link focus states for highly stylized components, ensuring predictable navigation for all users.

---
*PR created automatically by Jules for task [18279424264478314995](https://jules.google.com/task/18279424264478314995) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only changes limited to focus/keyboard interaction states, with no impact to routing or data handling.
> 
> **Overview**
> Adds **keyboard-accessible focus states** to the primary and secondary CTA links in `Hero` and `CTASection` by applying `focus-visible` outline removal plus a consistent `ring-2` highlight.
> 
> No behavior changes; this is a styling-only accessibility improvement for the prominent link-as-button components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d5ee781fa44e7cfdb83506b1b219bb702edb91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Enhanced focus state styling for call-to-action elements throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->