### PR TITLE
🎨 Palette: Improve form semantics for ReactionsEditor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-12-14 - ARIA Live Regions for Dynamic Messages
 **Learning:** Dynamic, auto-dismissing toast or inline notification messages (such as "Rule saved successfully" or error messages) must use ARIA live regions to be perceivable by screen reader users. Without `aria-live`, visually appearing text is silent to assistive technologies, leading to missed critical feedback.
 **Action:** Always add `role="status" aria-live="polite"` to dynamically appearing non-critical status messages (like success toasts), and `role="alert" aria-live="assertive"` to critical or error messages.
+
+## 2024-12-19 - Form Semantics for Enter-to-Submit
+**Learning:** Using a `<div>` to wrap collections of inputs and relying solely on a button's `onClick` handler breaks native "Enter to Submit" functionality. This is a common pattern in React apps that negatively impacts keyboard users and power users who expect standard form behavior.
+**Action:** Always wrap collections of related inputs in a `<form onSubmit={...}>` element, use `type="submit"` for the primary action button, and explicitly set `type="button"` on all other interactive buttons within the form to prevent accidental submission.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -240,7 +240,13 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
       {showForm && (
         <Panel>
           <h2 className="font-semibold text-text">Create Reaction Rule</h2>
-          <div className="mt-5 space-y-5">
+          <form
+            className="mt-5 space-y-5"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSave();
+            }}
+          >
             {/* Rule Name */}
             <div>
               <label htmlFor="rule-name" className="block text-xs font-medium uppercase tracking-wider text-muted">
@@ -264,6 +270,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               <div className="mt-2 grid grid-cols-2 gap-3">
                 {TRIGGER_OPTIONS.map((opt) => (
                   <button
+                    type="button"
                     key={opt.value}
                     onClick={() => setTriggerType(opt.value)}
                     aria-pressed={form.triggerType === opt.value}
@@ -295,6 +302,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   <div className="mt-2 flex flex-wrap gap-2 rounded-xl border border-accent-primary/10 bg-background/40 p-3">
                     {COMMON_EMOJIS.map((emoji) => (
                       <button
+                        type="button"
                         key={emoji}
                         onClick={() => setForm({ ...form, triggerValue: emoji })}
                         aria-label={`Select emoji ${emoji}`}
@@ -343,6 +351,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               <div className="mt-2 grid grid-cols-2 gap-3">
                 {RESPONSE_OPTIONS.map((opt) => (
                   <button
+                    type="button"
                     key={opt.value}
                     onClick={() => setResponseType(opt.value)}
                     aria-pressed={form.responseType === opt.value}
@@ -410,7 +419,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             <div className="flex gap-3 pt-2">
               <button
-                onClick={handleSave}
+                type="submit"
                 disabled={
                   saving ||
                   !form.name.trim() ||
@@ -422,6 +431,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 {saving ? 'Saving…' : 'Save Rule'}
               </button>
               <button
+                type="button"
                 onClick={() => {
                   setShowForm(false);
                   setForm(EMPTY_FORM);
@@ -431,7 +441,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 Cancel
               </button>
             </div>
-          </div>
+          </form>
         </Panel>
       )}
 


### PR DESCRIPTION
💡 **What:** Changed the wrapper `<div>` containing inputs in `ReactionsEditor.tsx` to a native `<form>` element. Configured the correct `type` properties on buttons inside the newly created form. Added a journal entry to the Palette `.Jules/palette.md` file noting this learning.
🎯 **Why:** To enable keyboard users and power users to simply press "Enter" while inside an input field to submit the form, instead of requiring them to explicitly navigate to and click the "Save Rule" button. Relying on an `onClick` div wrapper broke this native expectation.
♿ **Accessibility:** Form inputs must be wrapped in a `<form>` element to provide a clear relationship to a submit button, significantly improving keyboard accessibility and screen reader context handling for form submission.

---
*PR created automatically by Jules for task [5338778598170623406](https://jules.google.com/task/5338778598170623406) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility change that only adjusts client-side form semantics and button types; primary risk is unintended submit behavior, mitigated by explicitly setting non-submit buttons to `type="button"`.
> 
> **Overview**
> Enables native *Enter-to-submit* when creating reaction rules by converting the create-rule inputs wrapper in `ReactionsEditor.tsx` from a `div` to a real `form` with an `onSubmit` handler, and switching the primary action to `type="submit"`.
> 
> Prevents accidental submissions by explicitly setting all non-submit interactive buttons inside the form (option selectors, emoji picks, cancel) to `type="button"`.
> 
> Adds a Palette journal entry in `.Jules/palette.md` documenting the form-semantics accessibility guideline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1972a89b1cc249ca6d8800ff25cd47f63758c1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->