### PR TITLE
🎨 Palette: Add form semantics for Enter-to-Submit in ReactionsEditor

### DIFF
--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -240,7 +240,13 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
       {showForm && (
         <Panel>
           <h2 className="font-semibold text-text">Create Reaction Rule</h2>
-          <div className="mt-5 space-y-5">
+          <form
+            className="mt-5 space-y-5"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSave();
+            }}
+          >
             {/* Rule Name */}
             <div>
               <label htmlFor="rule-name" className="block text-xs font-medium uppercase tracking-wider text-muted">
@@ -265,6 +271,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 {TRIGGER_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
+                    type="button"
                     onClick={() => setTriggerType(opt.value)}
                     aria-pressed={form.triggerType === opt.value}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
@@ -296,6 +303,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                     {COMMON_EMOJIS.map((emoji) => (
                       <button
                         key={emoji}
+                        type="button"
                         onClick={() => setForm({ ...form, triggerValue: emoji })}
                         aria-label={`Select emoji ${emoji}`}
                         aria-pressed={form.triggerValue === emoji}
@@ -344,6 +352,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 {RESPONSE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
+                    type="button"
                     onClick={() => setResponseType(opt.value)}
                     aria-pressed={form.responseType === opt.value}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
@@ -410,7 +419,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             <div className="flex gap-3 pt-2">
               <button
-                onClick={handleSave}
+                type="submit"
                 disabled={
                   saving ||
                   !form.name.trim() ||
@@ -422,6 +431,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 {saving ? 'Saving…' : 'Save Rule'}
               </button>
               <button
+                type="button"
                 onClick={() => {
                   setShowForm(false);
                   setForm(EMPTY_FORM);
@@ -431,7 +441,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 Cancel
               </button>
             </div>
-          </div>
+          </form>
         </Panel>
       )}
 


### PR DESCRIPTION
💡 What: Added `<form>` wrapper to the ReactionsEditor to natively support Enter-to-Submit. Added `type="button"` to all secondary interactive elements inside the form boundary to prevent accidental submission.
🎯 Why: Enhances keyboard accessibility. Users expect to be able to hit "Enter" to save after finishing their typing in inputs, rather than having to manually tab to the "Save Rule" button.
♿ Accessibility: Improved keyboard navigation and interaction patterns for form submission.

---
*PR created automatically by Jules for task [14080594990596369459](https://jules.google.com/task/14080594990596369459) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts form submission behavior and button types; main risk is unintended submit/keyboard interaction regressions in the editor.
> 
> **Overview**
> **Improves keyboard/accessibility behavior in `ReactionsEditor`** by wrapping the “Create Reaction Rule” inputs in a real `<form>` and handling `onSubmit` to allow Enter-to-submit.
> 
> Updates interactive controls inside the form to use explicit `type="button"`, and changes “Save Rule” to `type="submit"`, preventing accidental submissions when selecting trigger/response options or emojis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b46325a6287634bf52dd14d813ce8fcd47fa7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rule creation form to properly handle submissions and button interactions, preventing accidental form triggers when selecting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->