### PR TITLE
🎨 Palette: Accessible Radio Groups in Reactions Editor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-12-14 - ARIA Live Regions for Dynamic Messages
 **Learning:** Dynamic, auto-dismissing toast or inline notification messages (such as "Rule saved successfully" or error messages) must use ARIA live regions to be perceivable by screen reader users. Without `aria-live`, visually appearing text is silent to assistive technologies, leading to missed critical feedback.
 **Action:** Always add `role="status" aria-live="polite"` to dynamically appearing non-critical status messages (like success toasts), and `role="alert" aria-live="assertive"` to critical or error messages.
+
+## 2024-05-07 - Accessible Custom Radio Groups
+**Learning:** When building custom radio button selections with `<button>`, using `aria-pressed` incorrectly treats them as individual toggles rather than mutually exclusive options. Wrapping them in a container with `role="radiogroup"` and applying `role="radio"` and `aria-checked` provides the correct semantic grouping for screen readers.
+**Action:** Always use `radiogroup` / `radio` for mutually exclusive options instead of independent toggles to ensure standard keyboard and screen reader accessibility patterns.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -264,16 +264,17 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Trigger Type */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <div id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Type
-              </label>
-              <div className="mt-2 grid grid-cols-2 gap-3">
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-3" role="radiogroup" aria-labelledby="trigger-type-label">
                 {TRIGGER_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
                     type="button"
+                    role="radio"
                     onClick={() => setTriggerType(opt.value)}
-                    aria-pressed={form.triggerType === opt.value}
+                    aria-checked={form.triggerType === opt.value}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
@@ -345,16 +346,17 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
             {/* Response Type */}
             <div>
-              <label className="block text-xs font-medium uppercase tracking-wider text-muted">
+              <div id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Type
-              </label>
-              <div className="mt-2 grid grid-cols-2 gap-3">
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-3" role="radiogroup" aria-labelledby="response-type-label">
                 {RESPONSE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
                     type="button"
+                    role="radio"
                     onClick={() => setResponseType(opt.value)}
-                    aria-pressed={form.responseType === opt.value}
+                    aria-checked={form.responseType === opt.value}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'


### PR DESCRIPTION
This pull request enhances the accessibility of the Reactions Editor by replacing custom toggle buttons with semantic ARIA radio groups. Screen readers will now correctly perceive these selections as mutually exclusive options. The `.Jules/palette.md` journal has also been updated with this learning.

---
*PR created automatically by Jules for task [11858403039959651255](https://jules.google.com/task/11858403039959651255) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to ARIA semantics/labeling for existing UI buttons and a documentation note, with no business logic or data flow changes.
> 
> **Overview**
> Improves accessibility in `ReactionsEditor` by converting the Trigger Type and Response Type option button grids from independent toggle semantics (`aria-pressed`) to proper mutually-exclusive radio semantics (`role="radiogroup"`/`role="radio"` + `aria-checked` and `aria-labelledby`).
> 
> Updates `.Jules/palette.md` with a new guideline documenting the `radiogroup`/`radio` pattern for custom button-based radio selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e09d142fee017194a25774438f66bb214ee54f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->