### PR TITLE
🎨 Palette: Improve form validation with required indicators and disabled button context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-07 - Accessible Custom Radio Groups
 **Learning:** When building custom radio button selections with `<button>`, using `aria-pressed` incorrectly treats them as individual toggles rather than mutually exclusive options. Wrapping them in a container with `role="radiogroup"` and applying `role="radio"` and `aria-checked` provides the correct semantic grouping for screen readers.
 **Action:** Always use `radiogroup` / `radio` for mutually exclusive options instead of independent toggles to ensure standard keyboard and screen reader accessibility patterns.
+
+## 2024-12-15 - Required Field Indicators and Submit Button Titles
+**Learning:** When creating forms with multiple required fields, relying solely on a disabled submit button can be frustrating for users who don't know what is missing. A common pattern in this app is to disable the submit button based on form state (`!form.name.trim() || ...`).
+**Action:** Always pair a disabled submit button with a helpful `title` attribute explaining the disabled state (e.g., `title={saving ? 'Saving...' : !isValid ? 'Please fill out all required fields' : undefined}`). In addition, ensure standard required visual indicators (a red `*` hidden from screen readers `aria-hidden="true"`) and semantic properties (`required`, `aria-required="true"`) are explicitly set on the inputs and labels to make expectations clear.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -250,11 +250,13 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
             {/* Rule Name */}
             <div>
               <label htmlFor="rule-name" className="block text-xs font-medium uppercase tracking-wider text-muted">
-                Rule Name
+                Rule Name <span className="text-accent-pink ml-1" aria-hidden="true">*</span>
               </label>
               <input
                 id="rule-name"
                 type="text"
+                required
+                aria-required="true"
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
                 placeholder="e.g. Magic Activation"
@@ -292,7 +294,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
             {/* Trigger Value */}
             <div>
               <label htmlFor="trigger-value" className="block text-xs font-medium uppercase tracking-wider text-muted">
-                Trigger Value
+                Trigger Value <span className="text-accent-pink ml-1" aria-hidden="true">*</span>
               </label>
 
               {form.triggerType === 'emoji' ? (
@@ -320,6 +322,8 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   <input
                     id="trigger-value"
                     type="text"
+                    required
+                    aria-required="true"
                     value={form.triggerValue}
                     onChange={(e) => setForm({ ...form, triggerValue: e.target.value })}
                     placeholder="Selected emoji will appear here, or type your own"
@@ -331,6 +335,8 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   <input
                     id="trigger-value"
                     type="text"
+                    required
+                    aria-required="true"
                     value={form.triggerValue}
                     onChange={(e) => setForm({ ...form, triggerValue: e.target.value })}
                     placeholder="Paste the sticker file ID from Telegram"
@@ -374,11 +380,13 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
             {/* Response Content */}
             <div>
               <label htmlFor="response-content" className="block text-xs font-medium uppercase tracking-wider text-muted">
-                Response Content
+                Response Content <span className="text-accent-pink ml-1" aria-hidden="true">*</span>
               </label>
               {form.responseType === 'message' ? (
                 <textarea
                   id="response-content"
+                  required
+                  aria-required="true"
                   value={form.responseContent}
                   onChange={(e) => setForm({ ...form, responseContent: e.target.value })}
                   placeholder={RESPONSE_PLACEHOLDER.message}
@@ -389,6 +397,8 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                 <input
                   id="response-content"
                   type="text"
+                  required
+                  aria-required="true"
                   value={form.responseContent}
                   onChange={(e) => setForm({ ...form, responseContent: e.target.value })}
                   placeholder={RESPONSE_PLACEHOLDER[form.responseType]}
@@ -427,6 +437,13 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   !form.name.trim() ||
                   !form.triggerValue.trim() ||
                   !form.responseContent.trim()
+                }
+                title={
+                  saving
+                    ? 'Saving…'
+                    : (!form.name.trim() || !form.triggerValue.trim() || !form.responseContent.trim())
+                      ? 'Please fill out all required fields'
+                      : undefined
                 }
                 className="rounded-lg bg-accent-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-accent-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 disabled:cursor-not-allowed disabled:opacity-40"
               >


### PR DESCRIPTION
This pull request adds an essential micro-UX enhancement by introducing explicit visual and semantic required indicators for form inputs in the `ReactionsEditor` component. Previously, the form had inputs without any required markers, making it difficult for users to understand why the "Save Rule" button was disabled. This change improves form validation with inline feedback, which aligns with Palette's core philosophy.

---
*PR created automatically by Jules for task [12306567845108852979](https://jules.google.com/task/12306567845108852979) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX/accessibility tweak limited to form markup; no backend, auth, or data-flow changes beyond native required validation and button tooltip text.
> 
> **Overview**
> Improves the `ReactionsEditor` “Create Reaction Rule” form by making required fields explicit and more accessible: labels now show a visual required indicator (`*`), and inputs/textarea add `required` + `aria-required="true"`.
> 
> Adds a `title` to the disabled submit button to explain why saving is unavailable (or that it’s currently saving), reducing “disabled with no context” confusion.
> 
> Updates `.Jules/palette.md` with a new accessibility guideline covering required-field indicators and disabled submit button titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f518645c52141462580a122dadd02653b7abb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->