### PR TITLE
🎨 Palette: Improve accessible semantic groupings for custom radio button options

### DIFF
--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -299,17 +299,18 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
 
               {form.triggerType === 'emoji' ? (
                 <>
-                  <p className="mt-1 text-xs text-muted">
+                  <p className="mt-1 text-xs text-muted" id="common-emojis-label">
                     Click an emoji to select it, or type your own below.
                   </p>
-                  <div className="mt-2 flex flex-wrap gap-2 rounded-xl border border-accent-primary/10 bg-background/40 p-3">
+                  <div className="mt-2 flex flex-wrap gap-2 rounded-xl border border-accent-primary/10 bg-background/40 p-3" role="radiogroup" aria-labelledby="common-emojis-label">
                     {COMMON_EMOJIS.map((emoji) => (
                       <button
                         key={emoji}
                         type="button"
+                        role="radio"
                         onClick={() => setForm({ ...form, triggerValue: emoji })}
                         aria-label={`Select emoji ${emoji}`}
-                        aria-pressed={form.triggerValue === emoji}
+                        aria-checked={form.triggerValue === emoji}
                         className={`rounded-lg px-2 py-1 text-lg transition hover:bg-accent-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                           form.triggerValue === emoji ? 'bg-accent-primary/30 ring-1 ring-accent-primary/50' : ''
                         }`}

--- a/packages/ui/src/components/MaskCard.tsx
+++ b/packages/ui/src/components/MaskCard.tsx
@@ -15,7 +15,8 @@ export const MaskCard = ({ mask, selected, onSelect }: MaskCardProps) => (
     whileHover={{ y: -4 }}
     whileTap={{ scale: 0.99 }}
     onClick={() => onSelect(mask)}
-    aria-pressed={selected}
+    role="radio"
+    aria-checked={selected}
     className={cn(
       'rounded-2xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/50',
       selected

--- a/packages/ui/src/components/MaskCatalog.tsx
+++ b/packages/ui/src/components/MaskCatalog.tsx
@@ -25,7 +25,7 @@ export const MaskCatalog = ({ masks }: MaskCatalogProps) => {
   return (
     <section className="space-y-6">
       <MaskHeroPreview selectedMask={selectedMask} />
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" role="radiogroup" aria-label="Mask Shapes">
         {masks.map((mask) => (
           <MaskCard key={mask.id} mask={mask} selected={mask.id === selectedMask.id} onSelect={() => setSelectedId(mask.id)} />
         ))}


### PR DESCRIPTION
- **💡 What:** Replaced isolated `aria-pressed` toggle patterns with proper `role="radiogroup"` and `role="radio"` with `aria-checked` properties.
- **🎯 Why:** Custom elements designed as mutually exclusive options (like selecting a single emoji or a single mask shape) were structured as independent toggles. This prevents screen readers from understanding the grouping context and the "select one" interaction model. Using `radiogroup` semantics makes the interface correctly parseable.
- **📸 Before/After:** (Visual changes only under-the-hood accessibility attributes)
- **♿ Accessibility:** Improves screen reader comprehension of custom single-select lists by adopting W3C recommended radio button roles over generic toggles.

---
*PR created automatically by Jules for task [10246981641385312124](https://jules.google.com/task/10246981641385312124) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to ARIA roles/attributes for screen reader semantics and should not affect business logic. Minor risk of unintended interaction differences in assistive tech if any consumers relied on `aria-pressed`.
> 
> **Overview**
> Updates custom single-select controls to use **radio button semantics** instead of independent toggle semantics.
> 
> In `ReactionsEditor`, the common emoji picker is now a labeled `radiogroup` with each emoji button exposed as a `radio` using `aria-checked`.
> 
> In the UI mask picker, `MaskCatalog` wraps cards in a `radiogroup`, and `MaskCard` now reports selection via `role="radio"` + `aria-checked` (replacing `aria-pressed`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfdd98576587d3c30850257231e1b5b847b1efc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->