### PR TITLE
🎨 Palette: Add accessible keyboard links to PackGrid

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-12-15 - Required Field Indicators and Submit Button Titles
 **Learning:** When creating forms with multiple required fields, relying solely on a disabled submit button can be frustrating for users who don't know what is missing. A common pattern in this app is to disable the submit button based on form state (`!form.name.trim() || ...`).
 **Action:** Always pair a disabled submit button with a helpful `title` attribute explaining the disabled state (e.g., `title={saving ? 'Saving...' : !isValid ? 'Please fill out all required fields' : undefined}`). In addition, ensure standard required visual indicators (a red `*` hidden from screen readers `aria-hidden="true"`) and semantic properties (`required`, `aria-required="true"`) are explicitly set on the inputs and labels to make expectations clear.
+
+## 2024-12-16 - Accessible Card Grid Links
+**Learning:** In grids of components (like `PackGrid`), wrapping interactive cards (`PackCard`) inside standard Next.js `<Link>` components is critical for making grid items accessible and navigable via keyboard. Without an interactive wrapping element like `<Link>` or `<button>`, users relying on keyboard navigation cannot access or focus these elements.
+**Action:** When constructing interactive grids mapping to distinct routes (such as a detail page), ensure you wrap the card content in an explicit `<Link>` element, and reliably apply standard focus styling to the wrapper (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50`) so its focused state is clearly visible.

--- a/packages/ui/src/components/PackGrid.tsx
+++ b/packages/ui/src/components/PackGrid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import type { ProductPack } from '@stixmagic/types';
 import { PackCard } from './PackCard';
 
@@ -18,7 +19,12 @@ export const PackGrid = ({ packs }: PackGridProps) => (
         viewport={{ once: true, margin: '-80px' }}
         transition={{ duration: 0.3, delay: index * 0.05 }}
       >
-        <PackCard pack={pack} className="h-full" />
+        <Link
+          href={`/packs/${pack.id}`}
+          className="block h-full rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
+        >
+          <PackCard pack={pack} className="h-full" />
+        </Link>
       </motion.div>
     ))}
   </section>


### PR DESCRIPTION
Wrapped `PackCard` components inside the `PackGrid` with an explicit Next.js `<Link>` element and focus-visible styling. Previously, grid items were not keyboard-navigable. This ensures that users relying on keyboard navigation can tab through the asset packs, easily discovering and interacting with them. Also added proper `focus-visible` styling (`focus-visible:ring-2 focus-visible:ring-accent-primary/50`) to provide clear visual feedback when a grid item receives keyboard focus.

---
*PR created automatically by Jules for task [17107316533459863893](https://jules.google.com/task/17107316533459863893) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that wraps existing cards in a `Link` and adds focus styling; main risk is minor layout/styling regressions or unintended nested-link behavior if `PackCard` already contains interactive elements.
> 
> **Overview**
> Makes `PackGrid` items keyboard-accessible by wrapping each `PackCard` in a Next.js `Link` to `/packs/{id}` and adding consistent `focus-visible` ring styling on the wrapper.
> 
> Updates the internal palette docs with an accessibility guideline for *interactive card grids* to ensure cards are wrapped in a focusable element with visible focus states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5face6c5ebd3297155106a67ca276b5558f4397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Grid cards are now interactive, allowing you to click cards to view detailed item information.
  * Enhanced keyboard accessibility with visible focus states on grid items for seamless navigation.

* **Documentation**
  * Added design pattern documentation for implementing accessible card grid links with keyboard navigation support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/stixmagic-web/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->