### PR TITLE
🎨 Palette: Add Accessible Radiogroup Navigation to Reactions Editor

### DIFF
--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -120,6 +120,32 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   const setResponseType = (responseType: ResponseType) =>
     setForm((prev) => ({ ...prev, responseType, responseContent: '' }));
 
+  const handleRadioGroupKeyDown = (
+    e: React.KeyboardEvent<HTMLDivElement>,
+    options: { value: string }[],
+    currentValue: string,
+    setValue: (val: any) => void
+  ) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) return;
+    e.preventDefault();
+    const currentIndex = options.findIndex((opt) => opt.value === currentValue);
+    let nextIndex = currentIndex;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      nextIndex = (currentIndex + 1) % options.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      nextIndex = (currentIndex - 1 + options.length) % options.length;
+    }
+    const nextValue = options[nextIndex].value;
+    setValue(nextValue);
+
+    // Cache currentTarget synchronously
+    const group = e.currentTarget;
+    setTimeout(() => {
+      const radios = Array.from(group.querySelectorAll('[role="radio"]')) as HTMLElement[];
+      radios[nextIndex]?.focus();
+    }, 0);
+  };
+
   const handleToggle = async (id: string, current: boolean) => {
     const previousRules = rules;
     setRules((prev) => prev.map((r) => (r.id === id ? { ...r, enabled: !current } : r)));
@@ -269,14 +295,20 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               <div id="trigger-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Trigger Type
               </div>
-              <div className="mt-2 grid grid-cols-2 gap-3" role="radiogroup" aria-labelledby="trigger-type-label">
-                {TRIGGER_OPTIONS.map((opt) => (
+              <div
+                className="mt-2 grid grid-cols-2 gap-3"
+                role="radiogroup"
+                aria-labelledby="trigger-type-label"
+                onKeyDown={(e) => handleRadioGroupKeyDown(e, TRIGGER_OPTIONS, form.triggerType, setTriggerType)}
+              >
+                {TRIGGER_OPTIONS.map((opt, i) => (
                   <button
                     key={opt.value}
                     type="button"
                     role="radio"
                     onClick={() => setTriggerType(opt.value)}
                     aria-checked={form.triggerType === opt.value}
+                    tabIndex={form.triggerType === opt.value || (!form.triggerType && i === 0) ? 0 : -1}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 ${
                       form.triggerType === opt.value
                         ? 'border-accent-primary/50 bg-accent-primary/15'
@@ -355,14 +387,20 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
               <div id="response-type-label" className="block text-xs font-medium uppercase tracking-wider text-muted">
                 Response Type
               </div>
-              <div className="mt-2 grid grid-cols-2 gap-3" role="radiogroup" aria-labelledby="response-type-label">
-                {RESPONSE_OPTIONS.map((opt) => (
+              <div
+                className="mt-2 grid grid-cols-2 gap-3"
+                role="radiogroup"
+                aria-labelledby="response-type-label"
+                onKeyDown={(e) => handleRadioGroupKeyDown(e, RESPONSE_OPTIONS, form.responseType, setResponseType)}
+              >
+                {RESPONSE_OPTIONS.map((opt, i) => (
                   <button
                     key={opt.value}
                     type="button"
                     role="radio"
                     onClick={() => setResponseType(opt.value)}
                     aria-checked={form.responseType === opt.value}
+                    tabIndex={form.responseType === opt.value || (!form.responseType && i === 0) ? 0 : -1}
                     className={`flex flex-col gap-1 rounded-xl border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-violet/50 ${
                       form.responseType === opt.value
                         ? 'border-accent-violet/50 bg-accent-violet/15'

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import type { ReactionRule, TriggerType, ResponseType } from '@stixmagic/types';
-import { Panel } from '@stixmagic/ui';
+import { getRovingRadioGroupNextIndex, Panel } from '@stixmagic/ui';
 import { getRules, createRule, toggleRule, deleteRule, isDemoModeEnabled } from '../../../lib/api-client';
 
 interface Props {
@@ -120,21 +120,17 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   const setResponseType = (responseType: ResponseType) =>
     setForm((prev) => ({ ...prev, responseType, responseContent: '' }));
 
-  const handleRadioGroupKeyDown = (
+  const handleRadioGroupKeyDown = <TValue extends string>(
     e: React.KeyboardEvent<HTMLDivElement>,
-    options: { value: string }[],
-    currentValue: string,
-    setValue: (val: any) => void
+    options: { value: TValue }[],
+    currentValue: TValue,
+    setValue: (val: TValue) => void
   ) => {
-    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) return;
-    e.preventDefault();
     const currentIndex = options.findIndex((opt) => opt.value === currentValue);
-    let nextIndex = currentIndex;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-      nextIndex = (currentIndex + 1) % options.length;
-    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-      nextIndex = (currentIndex - 1 + options.length) % options.length;
-    }
+    const nextIndex = getRovingRadioGroupNextIndex(e.key, currentIndex, options.length);
+    if (nextIndex === null) return;
+
+    e.preventDefault();
     const nextValue = options[nextIndex].value;
     setValue(nextValue);
 

--- a/packages/ui/src/components/MaskCatalog.tsx
+++ b/packages/ui/src/components/MaskCatalog.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useRef } from 'react';
 import type { MaskDefinition } from '@stixmagic/types';
+import { getRovingRadioGroupNextIndex } from '../lib/rovingRadioGroup';
 import { MaskCard } from './MaskCard';
 import { MaskHeroPreview } from './MaskHeroPreview';
 import { Panel } from './Panel';
@@ -20,19 +21,14 @@ export const MaskCatalog = ({ masks }: MaskCatalogProps) => {
   );
 
   const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
-    let nextIndex = index;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-      e.preventDefault();
-      nextIndex = (index + 1) % masks.length;
-    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-      e.preventDefault();
-      nextIndex = (index - 1 + masks.length) % masks.length;
-    }
+    const nextIndex = getRovingRadioGroupNextIndex(e.key, index, masks.length);
+    if (nextIndex === null) return;
 
-    if (nextIndex !== index) {
-      setSelectedId(masks[nextIndex].id);
-      cardRefs.current[nextIndex]?.focus();
-    }
+    e.preventDefault();
+    if (nextIndex === index) return;
+
+    setSelectedId(masks[nextIndex].id);
+    cardRefs.current[nextIndex]?.focus();
   };
 
   if (!selectedMask) {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,3 +16,4 @@ export * from './components/PackGrid';
 export * from './components/Panel';
 export * from './components/Roadmap';
 export * from './components/Tabs';
+export * from './lib/rovingRadioGroup';

--- a/packages/ui/src/lib/rovingRadioGroup.ts
+++ b/packages/ui/src/lib/rovingRadioGroup.ts
@@ -1,0 +1,19 @@
+export function getRovingRadioGroupNextIndex(
+  key: string,
+  currentIndex: number,
+  itemCount: number
+): number | null {
+  if (itemCount <= 0 || currentIndex < 0) {
+    return null;
+  }
+
+  if (key === 'ArrowRight' || key === 'ArrowDown') {
+    return (currentIndex + 1) % itemCount;
+  }
+
+  if (key === 'ArrowLeft' || key === 'ArrowUp') {
+    return (currentIndex - 1 + itemCount) % itemCount;
+  }
+
+  return null;
+}

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**"]
+      "outputs": ["dist/**", ".next/**", "out/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "apps/web/out/**"]
+      "outputs": ["dist/**", ".next/**", "out/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "out/**"]
+      "outputs": ["dist/**", ".next/**", "**/out/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "**/out/**"]
+      "outputs": ["dist/**", ".next/**", "apps/web/out/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
Added standard keyboard navigation (arrow keys and roving tabIndex) to the radio groups in `ReactionsEditor.tsx`.

---
*PR created automatically by Jules for task [8083575773993161257](https://jules.google.com/task/8083575773993161257) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to client-side keyboard handling/tabIndex behavior and a small shared helper, with no backend, auth, or data-model impact.
> 
> **Overview**
> Adds accessible *roving `tabIndex` + arrow-key navigation* to the `Trigger Type` and `Response Type` radiogroups in `ReactionsEditor`, including focus movement to the newly selected option.
> 
> Extracts the arrow-key index calculation into a shared `getRovingRadioGroupNextIndex` helper (used by both `ReactionsEditor` and `MaskCatalog`) and exports it from `@stixmagic/ui`.
> 
> Updates `turbo.json` build task outputs to also cache `out/**`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5087a34f68d1752b1ab0a30303f6050d5ea9903b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced keyboard navigation: Use arrow keys to select reaction triggers and responses in the group editor with wraparound support
  * Improved arrow key navigation for browsing mask catalog options seamlessly

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/stixmagic-web/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->