### PR TITLE
🎨 Palette: Add keyboard navigation to Tabs component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-12-16 - Accessible Radiogroup Navigation
 **Learning:** For custom mutually exclusive selection UI components built with buttons (like the `MaskCatalog`), simple `aria-pressed` toggles are insufficient for screen readers. Using `role="radiogroup"` with `role="radio"` and `aria-checked` accurately communicates semantic grouping. More importantly, keyboard accessibility for these groups must strictly follow W3C ARIA specs: implementing a roving `tabIndex` (`selected ? 0 : -1`) combined with arrow-key navigation logic, ensuring the entire group acts as a single tab stop rather than forcing users to tab through every individual option.
 **Action:** When creating mutually exclusive options out of non-native inputs, always apply the complete `radiogroup` pattern, including arrow-key-based focus management and roving tab indexes.
+
+## 2024-05-16 - Roving TabIndex for ARIA Tabs
+**Learning:** Standard ARIA Tab components built manually require more than just `role="tab"` and `role="tabpanel"`. They must implement a roving tabindex (`tabIndex={isSelected ? 0 : -1}` on the tabs) and arrow-key navigation so the entire tablist acts as a single tab stop. Additionally, the active `tabpanel` itself should have `tabIndex={0}` and a visible focus style so users can tab directly into the active pane from the tablist.
+**Action:** When implementing custom tab components, always verify that the roving tabindex pattern is implemented with arrow key navigation, and ensure the content pane is focusable.

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -21,6 +21,8 @@ export const Tabs = ({ items }: TabsProps) => {
   const active = useMemo(() => items.find((item) => item.id === activeId) ?? items[0], [activeId, items]);
 
   const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+
     const nextIndex = getRovingRadioGroupNextIndex(e.key, index, items.length);
     if (nextIndex === null) return;
 

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -21,8 +21,6 @@ export const Tabs = ({ items }: TabsProps) => {
   const active = useMemo(() => items.find((item) => item.id === activeId) ?? items[0], [activeId, items]);
 
   const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
-    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-
     const nextIndex = getRovingRadioGroupNextIndex(e.key, index, items.length);
     if (nextIndex === null) return;
 

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useRef } from 'react';
+import { getRovingRadioGroupNextIndex } from '../lib/rovingRadioGroup';
 import { cn } from '../lib/cn';
 
 export interface TabItem {
@@ -15,36 +16,57 @@ interface TabsProps {
 
 export const Tabs = ({ items }: TabsProps) => {
   const [activeId, setActiveId] = useState(items[0]?.id ?? '');
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const active = useMemo(() => items.find((item) => item.id === activeId) ?? items[0], [activeId, items]);
+
+  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    const nextIndex = getRovingRadioGroupNextIndex(e.key, index, items.length);
+    if (nextIndex === null) return;
+
+    e.preventDefault();
+    if (nextIndex === index) return;
+
+    setActiveId(items[nextIndex].id);
+    tabRefs.current[nextIndex]?.focus();
+  };
 
   return (
     <section className="rounded-2xl border border-white/10 bg-panel p-6">
       <div className="flex flex-wrap gap-2" role="tablist" aria-label="Content Tabs">
-        {items.map((item) => (
-          <button
-            key={item.id}
-            id={`tab-${item.id}`}
-            role="tab"
-            aria-selected={item.id === active?.id}
-            aria-controls={`tabpanel-${item.id}`}
-            onClick={() => setActiveId(item.id)}
-            className={cn(
-              'rounded-lg px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
-              item.id === active?.id
-                ? 'bg-accent-primary text-text'
-                : 'bg-panel-secondary text-muted hover:text-text'
-            )}
-          >
-            {item.label}
-          </button>
-        ))}
+        {items.map((item, index) => {
+          const isSelected = item.id === active?.id;
+          return (
+            <button
+              key={item.id}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              id={`tab-${item.id}`}
+              role="tab"
+              aria-selected={isSelected}
+              aria-controls={`tabpanel-${item.id}`}
+              tabIndex={isSelected ? 0 : -1}
+              onClick={() => setActiveId(item.id)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className={cn(
+                'rounded-lg px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
+                isSelected
+                  ? 'bg-accent-primary text-text'
+                  : 'bg-panel-secondary text-muted hover:text-text'
+              )}
+            >
+              {item.label}
+            </button>
+          );
+        })}
       </div>
       <div
         id={`tabpanel-${active?.id}`}
         role="tabpanel"
         aria-labelledby={`tab-${active?.id}`}
-        className="mt-4 text-sm leading-relaxed text-muted"
+        tabIndex={0}
+        className="mt-4 rounded-lg p-1 text-sm leading-relaxed text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
       >
         <p>{active?.content}</p>
       </div>

--- a/services/api/data/jobs.json
+++ b/services/api/data/jobs.json
@@ -20,27 +20,5 @@
     "attempts": 0,
     "maxAttempts": 3,
     "runAt": "2026-04-15T02:04:21.820Z"
-  },
-  {
-    "id": "0728f44a-75ae-432a-8524-b4e116db293a",
-    "jobType": "trigger.execute",
-    "payload": {
-      "messageId": 1
-    },
-    "status": "completed",
-    "attempts": 0,
-    "maxAttempts": 3,
-    "runAt": "2026-05-16T01:21:40.352Z"
-  },
-  {
-    "id": "cb541eb8-d426-4827-bfec-54793142073b",
-    "jobType": "trigger.execute",
-    "payload": {
-      "messageId": 1
-    },
-    "status": "completed",
-    "attempts": 0,
-    "maxAttempts": 3,
-    "runAt": "2026-05-16T01:23:04.955Z"
   }
 ]

--- a/services/api/data/jobs.json
+++ b/services/api/data/jobs.json
@@ -20,5 +20,27 @@
     "attempts": 0,
     "maxAttempts": 3,
     "runAt": "2026-04-15T02:04:21.820Z"
+  },
+  {
+    "id": "0728f44a-75ae-432a-8524-b4e116db293a",
+    "jobType": "trigger.execute",
+    "payload": {
+      "messageId": 1
+    },
+    "status": "completed",
+    "attempts": 0,
+    "maxAttempts": 3,
+    "runAt": "2026-05-16T01:21:40.352Z"
+  },
+  {
+    "id": "cb541eb8-d426-4827-bfec-54793142073b",
+    "jobType": "trigger.execute",
+    "payload": {
+      "messageId": 1
+    },
+    "status": "completed",
+    "attempts": 0,
+    "maxAttempts": 3,
+    "runAt": "2026-05-16T01:23:04.955Z"
   }
 ]


### PR DESCRIPTION
💡 **What:** Added comprehensive keyboard accessibility to the `Tabs` UI component, ensuring it fully meets W3C ARIA authoring practices for tabs.
🎯 **Why:** Custom tab components without explicit keyboard navigation patterns cause "focus traps" or require users to tediously tab through every inactive tab to reach the content. This change groups the tabs into a single tab stop with arrow-key switching, and makes the content pane itself focusable.
♿ **Accessibility:** Added roving `tabIndex`, arrow-key handlers, and a focusable `tabpanel` with visible focus rings to support screen reader users and keyboard navigators.

---
*PR created automatically by Jules for task [14364263115581566480](https://jules.google.com/task/14364263115581566480) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI accessibility change; main risk is unintended keyboard/focus behavior changes in the `Tabs` component for consumers relying on previous tabbing order.
> 
> **Overview**
> Improves `Tabs` keyboard accessibility by implementing a roving `tabIndex` and arrow-key navigation across tabs, using shared `getRovingRadioGroupNextIndex` logic and focusing the newly selected tab.
> 
> Makes the active `tabpanel` programmatically focusable (`tabIndex={0}`) and adds visible focus-ring styling to the panel so keyboard users can move from the tablist into the content area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e49786272b340972b407936f63ac0015a7fa0d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Tabs component now supports arrow-key navigation to switch between tabs with improved keyboard accessibility.
* Active tab panels are now focusable with visible focus indicators, enhancing screen reader and keyboard user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/stixmagic-web/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->