### PR TITLE
🎨 Palette: Improve keyboard focus state on not-found page link

### DIFF
--- a/apps/web/app/packs/[id]/not-found.tsx
+++ b/apps/web/app/packs/[id]/not-found.tsx
@@ -16,7 +16,7 @@ export default function PackNotFound() {
         <div className="mt-6">
           <Link
             href="/packs"
-            className="inline-flex rounded-xl bg-accent-primary px-5 py-2.5 text-sm font-semibold text-text transition hover:opacity-90"
+            className="inline-flex rounded-xl bg-accent-primary px-5 py-2.5 text-sm font-semibold text-text transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
           >
             Browse all packs
           </Link>


### PR DESCRIPTION
💡 What: Added `focus-visible` styles to the "Browse all packs" link on the `[id]/not-found.tsx` page.
🎯 Why: Standard HTML links frequently lack prominent keyboard focus outlines. Explicitly adding these preserves consistent keyboard-driven discovery across the layout, matching the rest of the application.
♿ Accessibility: Improved keyboard navigation feedback for users relying on tab navigation.

---
*PR created automatically by Jules for task [16312007465397741107](https://jules.google.com/task/16312007465397741107) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds keyboard focus styles to a single link with no behavioral or data-flow impact.
> 
> **Overview**
> Improves accessibility on the packs `[id]` not-found page by adding `focus-visible` outline/ring styles to the "Browse all packs" link, aligning keyboard focus treatment with other links in the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597dabf0ea6340d5464619325e6c5788cf3c998d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->