### PR TITLE
🎨 Palette: Make PackGrid cards clickable and keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-05-16 - Roving TabIndex for ARIA Tabs
 **Learning:** Standard ARIA Tab components built manually require more than just `role="tab"` and `role="tabpanel"`. They must implement a roving tabindex (`tabIndex={isSelected ? 0 : -1}` on the tabs) and arrow-key navigation so the entire tablist acts as a single tab stop. Additionally, the active `tabpanel` itself should have `tabIndex={0}` and a visible focus style so users can tab directly into the active pane from the tablist.
 **Action:** When implementing custom tab components, always verify that the roving tabindex pattern is implemented with arrow key navigation, and ensure the content pane is focusable.
+
+## 2024-12-16 - Make Cards Fully Clickable with Links
+**Learning:** Grids of content cards (like the packs grid) that are intended to navigate users to detail pages often miss actual semantic links if the card is built mostly for display (e.g. wrapped in an animation div instead of an anchor). This hurts accessibility (no tab focus, screen readers can't activate them) and general usability (can't right-click or middle-click to open in a new tab).
+**Action:** When a visual card represents a destination, always wrap the card component (or its interactive area) in a standard semantic `<Link>` component with `focus-visible` ring styling to maintain accessibility and expected browser behaviors.

--- a/packages/ui/src/components/PackGrid.tsx
+++ b/packages/ui/src/components/PackGrid.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import type { Route } from 'next';
 import type { ProductPack } from '@stixmagic/types';
 import { PackCard } from './PackCard';
 
@@ -20,7 +21,7 @@ export const PackGrid = ({ packs }: PackGridProps) => (
         transition={{ duration: 0.3, delay: index * 0.05 }}
       >
         <Link
-          href={`/packs/${pack.id}`}
+          href={`/packs/${pack.id}` as Route}
           className="block h-full rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
         >
           <PackCard pack={pack} className="h-full" />

--- a/packages/ui/src/components/PackGrid.tsx
+++ b/packages/ui/src/components/PackGrid.tsx
@@ -2,7 +2,6 @@
 
 import { motion } from 'framer-motion';
 import Link from 'next/link';
-import type { Route } from 'next';
 import type { ProductPack } from '@stixmagic/types';
 import { PackCard } from './PackCard';
 
@@ -21,7 +20,7 @@ export const PackGrid = ({ packs }: PackGridProps) => (
         transition={{ duration: 0.3, delay: index * 0.05 }}
       >
         <Link
-          href={`/packs/${pack.id}` as Route}
+          href={{ pathname: '/packs/[id]', query: { id: pack.id } }}
           className="block h-full rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
         >
           <PackCard pack={pack} className="h-full" />

--- a/packages/ui/src/components/PackGrid.tsx
+++ b/packages/ui/src/components/PackGrid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import Link from 'next/link';
 import type { ProductPack } from '@stixmagic/types';
 import { PackCard } from './PackCard';
 
@@ -18,7 +19,12 @@ export const PackGrid = ({ packs }: PackGridProps) => (
         viewport={{ once: true, margin: '-80px' }}
         transition={{ duration: 0.3, delay: index * 0.05 }}
       >
-        <PackCard pack={pack} className="h-full" />
+        <Link
+          href={`/packs/${pack.id}`}
+          className="block h-full rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
+        >
+          <PackCard pack={pack} className="h-full" />
+        </Link>
       </motion.div>
     ))}
   </section>


### PR DESCRIPTION
Wrapped `PackCard` components in `PackGrid.tsx` with a standard Next.js `<Link>` component to ensure they are clickable, keyboard accessible, and compatible with standard browser navigation behaviors.

---
*PR created automatically by Jules for task [7349188123241047980](https://jules.google.com/task/7349188123241047980) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility change that wraps existing cards in a Next.js `Link`; main risk is minor layout/styling or click/hover behavior changes due to the new anchor wrapper.
> 
> **Overview**
> **Pack cards in `PackGrid` are now real links.** Each `PackCard` is wrapped in a Next.js `Link` to `/packs/[id]`, making the whole card clickable and enabling standard browser behaviors (keyboard focus, open in new tab).
> 
> Adds explicit `focus-visible` ring styling on the link wrapper and updates the palette guidance doc with this “clickable card as link” accessibility pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227612219d7f68370effe57b84cad6c08360687a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->