### PR TITLE
🎨 Palette: Add ARIA status role to AssetPreview loading spinner

### DIFF
--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -48,7 +48,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
     <div className="relative flex h-full w-full items-center justify-center">
       {state === 'loading' && (
         <div className="absolute inset-0 flex items-center justify-center">
-          <div className="h-5 w-5 animate-spin rounded-full border-2 border-accent-primary/20 border-t-accent-primary" />
+          <div
+            className="h-5 w-5 animate-spin rounded-full border-2 border-accent-primary/20 border-t-accent-primary"
+            role="status"
+            aria-label="Loading preview"
+          />
         </div>
       )}
       <img

--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { PreviewState } from '@stixmagic/types';
 import { cn } from '../lib/cn';
 
@@ -20,11 +20,6 @@ interface AssetPreviewProps {
  */
 export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) => {
   const [state, setState] = useState<PreviewState>(url === '' ? 'pending' : 'loading');
-  const [statusMessage, setStatusMessage] = useState('');
-
-  useEffect(() => {
-    setStatusMessage(state === 'loading' ? 'Loading preview' : '');
-  }, [state]);
 
   if (state === 'pending') {
     return (
@@ -51,14 +46,12 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   return (
     <div className="relative flex h-full w-full items-center justify-center">
-      <div className="sr-only" role="status" aria-atomic="true">
-        {statusMessage}
-      </div>
       {state === 'loading' && (
         <div className="absolute inset-0 flex items-center justify-center">
           <div
             className="h-5 w-5 animate-spin rounded-full border-2 border-accent-primary/20 border-t-accent-primary"
-            aria-hidden="true"
+            role="status"
+            aria-label="Loading preview"
           />
         </div>
       )}

--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { PreviewState } from '@stixmagic/types';
 import { cn } from '../lib/cn';
 
@@ -20,6 +20,11 @@ interface AssetPreviewProps {
  */
 export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) => {
   const [state, setState] = useState<PreviewState>(url === '' ? 'pending' : 'loading');
+  const [statusMessage, setStatusMessage] = useState('');
+
+  useEffect(() => {
+    setStatusMessage(state === 'loading' ? 'Loading preview' : '');
+  }, [state]);
 
   if (state === 'pending') {
     return (
@@ -46,12 +51,14 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   return (
     <div className="relative flex h-full w-full items-center justify-center">
+      <div className="sr-only" role="status" aria-atomic="true">
+        {statusMessage}
+      </div>
       {state === 'loading' && (
         <div className="absolute inset-0 flex items-center justify-center">
           <div
             className="h-5 w-5 animate-spin rounded-full border-2 border-accent-primary/20 border-t-accent-primary"
-            role="status"
-            aria-label="Loading preview"
+            aria-hidden="true"
           />
         </div>
       )}


### PR DESCRIPTION
💡 What: Added `role="status"` and `aria-label="Loading preview"` to the animated loading spinner `div` in `AssetPreview.tsx`.
🎯 Why: Ensures that visually impaired users relying on screen readers are notified when a preview image is in the loading state, since the spinner was previously just a visual CSS animation.
♿ Accessibility: Improves accessibility by making CSS-only loading indicators perceivable to assistive technologies.

---
*PR created automatically by Jules for task [1772014312366780998](https://jules.google.com/task/1772014312366780998) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds accessibility attributes to a loading spinner without changing data flow or business logic.
> 
> **Overview**
> Improves accessibility of `AssetPreview` by adding `role="status"` and an `aria-label` to the CSS loading spinner so screen readers can announce the loading state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98518f477247ef904a04cca2b8276b7a93152dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset preview loading status is now announced to assistive technology users, improving experience for screen reader users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/stixmagic-web/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->