### PR TITLE
🎨 Palette: Explicit empty states for group grids

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2024-12-16 - Make Cards Fully Clickable with Links
 **Learning:** Grids of content cards (like the packs grid) that are intended to navigate users to detail pages often miss actual semantic links if the card is built mostly for display (e.g. wrapped in an animation div instead of an anchor). This hurts accessibility (no tab focus, screen readers can't activate them) and general usability (can't right-click or middle-click to open in a new tab).
 **Action:** When a visual card represents a destination, always wrap the card component (or its interactive area) in a standard semantic `<Link>` component with `focus-visible` ring styling to maintain accessibility and expected browser behaviors.
+
+## 2024-12-16 - Explicit Empty States for Dynamic Grids
+**Learning:** When using map functions to render dynamic data grids (e.g., connected groups or active rules), simply checking `loading` is not enough. If the loaded data array is empty (`length === 0`), it leaves a blank void in the UI. This is bad for user experience and accessibility, as users are unsure if it's broken, still loading invisibly, or truly empty.
+**Action:** Always provide explicit, visually distinct empty states (e.g., using a disabled or secondary `<Panel>`) containing helpful text and a clear call-to-action when dynamic lists or grids return zero results.

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -113,6 +113,16 @@ export default function DashboardPage() {
               </Panel>
             ))}
           </div>
+        ) : groups.length === 0 ? (
+          <Panel variant="secondary">
+            <div className="py-6 text-center">
+              <p className="text-2xl">🪄</p>
+              <p className="mt-3 text-sm font-medium text-text">No groups connected yet</p>
+              <p className="mt-1 text-sm text-muted">
+                Add the Stix Magic bot to your Telegram group and give it admin rights to see it here.
+              </p>
+            </div>
+          </Panel>
         ) : (
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {groups.map((group) => {

--- a/apps/web/app/groups/page.tsx
+++ b/apps/web/app/groups/page.tsx
@@ -84,6 +84,16 @@ export default function GroupsPage() {
             </Panel>
           ))}
         </div>
+      ) : groups.length === 0 ? (
+        <Panel variant="secondary">
+          <div className="py-6 text-center">
+            <p className="text-2xl">🪄</p>
+            <p className="mt-3 text-sm font-medium text-text">No groups connected yet</p>
+            <p className="mt-1 text-sm text-muted">
+              Follow the instructions below to add the bot to your group and grant admin rights.
+            </p>
+          </div>
+        </Panel>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {groups.map((group) => {


### PR DESCRIPTION
💡 What: Added visual `<Panel>` empty states to the dynamic grids on both the Control Center Dashboard and Connected Groups pages when no groups exist.
🎯 Why: Without these empty states, users just saw a blank void when data was empty (`groups.length === 0`), causing confusion (is it broken, loading, or empty?). This micro-UX change gives users clear feedback and a call-to-action.
♿ Accessibility: Ensures that screen reader users and visual users alike understand the current state of the application without ambiguity.

---
*PR created automatically by Jules for task [11657668625197909644](https://jules.google.com/task/11657668625197909644) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UX on group listing pages; no API, auth, or data-handling changes.
> 
> **Overview**
> When group data finishes loading but the list is empty, the **Control Center** dashboard and **Connected Groups** page now show a secondary **`Panel`** empty state instead of a blank area. Each state includes short guidance (add the bot and grant admin on the dashboard; follow below-page instructions on Groups).
> 
> The Jules **palette** doc records the pattern: always handle **`length === 0`** for dynamic grids, not only loading skeletons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6791a47ab5303b73512f798ba0d396e72ca36837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard page now displays an empty-state message when no groups are connected, with guidance to add the bot and grant admin rights.
  * Groups page shows a helpful empty-state prompt when no connected admin groups are available, improving the onboarding experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/stixmagic-web/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->