### PR TITLE
🎨 Palette: Improve loading state UX and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,14 @@
 ## 2024-12-16 - Explicit Empty States for Dynamic Grids
 **Learning:** When using map functions to render dynamic data grids (e.g., connected groups or active rules), simply checking `loading` is not enough. If the loaded data array is empty (`length === 0`), it leaves a blank void in the UI. This is bad for user experience and accessibility, as users are unsure if it's broken, still loading invisibly, or truly empty.
 **Action:** Always provide explicit, visually distinct empty states (e.g., using a disabled or secondary `<Panel>`) containing helpful text and a clear call-to-action when dynamic lists or grids return zero results.
+
+## 2024-06-03 - Added SVG Loading Spinner to Async Button
+**Learning:** Adding an inline SVG loading spinner to an async submit button gives much better immediate visual feedback that a process is running compared to just updating the button text (e.g. from "Save" to "Saving...").
+**Action:** Always include an `aria-hidden="true"` SVG spinner next to the text on asynchronous primary action buttons to convey loading state, and use `inline-flex items-center justify-center gap-2` on the button itself.
+## 2026-06-11 - [Grid Components Accessibility and UX Polish]
+**Learning:** When building dynamic grid or list components (like `PackGrid`, `GalleryGrid`), it's crucial for accessibility to use semantic list wrappers (`<ul>` and `<li>`) so assistive technologies can announce the number of items. Additionally, explicitly handling the empty state (e.g., providing a visually distinct `<Panel>` with guidance) avoids rendering a confusing blank space when no items match.
+**Action:** Always verify that mapped list/grid components in `@stixmagic/ui` default to semantic `<ul>` and `<li>` structures, and explicitly render an empty state UI when array lengths are zero.
+
+## 2026-06-19 - Accessible "Coming Soon" Tabs/Buttons
+**Learning:** When implementing 'Coming Soon' tabs or similar inactive buttons, using the native `disabled` attribute completely removes them from the keyboard navigation sequence. This prevents screen reader users and keyboard navigators from discovering what features are upcoming.
+**Action:** Always use `aria-disabled="true"` instead of the native `disabled` attribute for these types of elements. Ensure they remain focusable and continue to use CSS utility classes (e.g., `opacity-50 cursor-not-allowed hover:text-muted/50`) to visually simulate the disabled state.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -479,8 +479,14 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                       ? 'Please fill out all required fields'
                       : undefined
                 }
-                className="rounded-lg bg-accent-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-accent-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex items-center gap-2 rounded-lg bg-accent-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-accent-indigo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 disabled:cursor-not-allowed disabled:opacity-40"
               >
+                {saving && (
+                  <svg className="h-4 w-4 animate-spin text-white" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                )}
                 {saving ? 'Saving…' : 'Save Rule'}
               </button>
               <button
@@ -499,7 +505,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
       )}
 
       {loading ? (
-        <div className="space-y-3">
+        <div className="space-y-3" role="status" aria-label="Loading rules">
           {[1, 2, 3].map((i) => (
             <Panel key={i} variant="secondary" className="animate-pulse">
               <div className="flex items-center gap-4">

--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,7 +23,7 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div role="status" className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
@@ -35,6 +35,7 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
   if (state === 'failed') {
     return (
       <div
+        role="status"
         className="flex h-full w-full flex-col items-center justify-center gap-1"
         aria-label="Preview unavailable"
       >


### PR DESCRIPTION
💡 **What:** 
- Added an animated SVG loading spinner to the "Save Rule" button during the `saving` state in the `ReactionsEditor` component.
- Applied `role="status"` and `aria-label="Loading rules"` to the skeleton loading container in `ReactionsEditor.tsx`.
- Applied `role="status"` to the `pending` and `failed` state containers in `AssetPreview.tsx`.

🎯 **Why:** 
- Providing a visual spinner alongside text changes gives users immediate, unambiguous feedback that an async operation is occurring. 
- Using `aria-label` on generic `<div>` elements without a specific role is often ignored by screen readers. Adding `role="status"` ensures that screen reader users are properly informed when content is pending, loading, or has failed.

♿ **Accessibility:**
- Improved screen reader announcements for skeleton loaders and asset preview placeholder states by turning them into valid live regions (`role="status"`).
- Explicitly marked the SVG spinner with `aria-hidden="true"` so it does not interfere with the button's text reading.

---
*PR created automatically by Jules for task [7331382921731695049](https://jules.google.com/task/7331382921731695049) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI and ARIA tweaks with no API, auth, or data-handling changes.
> 
> **Overview**
> Improves **loading feedback** and **screen reader** behavior for reaction-rule saves, rule list skeletons, and shared asset previews.
> 
> In **`ReactionsEditor`**, the **Save Rule** submit control now shows an inline **spinning icon** while `saving` is true (decorative via `aria-hidden`), with flex layout so icon and label align. The rules **skeleton list** is exposed as a **`role="status"`** region with **`aria-label="Loading rules"`** so assistive tech can announce that rules are loading.
> 
> In **`AssetPreview`**, the **pending** and **failed** placeholder panels gain **`role="status"`** so their existing `aria-label` values behave as proper status regions, consistent with the component’s loading spinner status region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74749e94487ad15b7428725bcbc466284d527bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->