### PR TITLE
🎨 Palette: Semantic List Wrappers for Grid Components

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,34 +6,35 @@ import {
   HeroAssetShowcase,
   HowItWorks,
   Panel,
-  Roadmap
-} from '@stixmagic/ui';
-import { loadPipelineManifest } from './integrations/manifest';
+  Roadmap,
+} from "@stixmagic/ui";
+import { loadPipelineManifest } from "./integrations/manifest";
 
 const features = [
   {
-    tag: 'Motion Alphabet',
-    title: 'Animated letter packs',
-    description: 'A–Z letters rendered as looping GIFs, WebMs, and overlay-ready assets for any production workflow.'
+    tag: "Motion Alphabet",
+    title: "Animated letter packs",
+    description:
+      "A–Z letters rendered as looping GIFs, WebMs, and overlay-ready assets for any production workflow.",
   },
   {
-    tag: 'Sticker Engine',
-    title: 'Visual asset pipeline',
+    tag: "Sticker Engine",
+    title: "Visual asset pipeline",
     description:
-      'The MagicStix bot pipeline generates stickers, animated emojis, signals, and overlays as production-ready exports.'
+      "The MagicStix bot pipeline generates stickers, animated emojis, signals, and overlays as production-ready exports.",
   },
   {
-    tag: 'Pack Catalog',
-    title: 'Modular asset packs',
+    tag: "Pack Catalog",
+    title: "Modular asset packs",
     description:
-      'Browse curated packs — DJ sets, neon signals, cloud motifs, emoji reactions, and more — ready to drop into any stream or chat.'
+      "Browse curated packs — DJ sets, neon signals, cloud motifs, emoji reactions, and more — ready to drop into any stream or chat.",
   },
   {
-    tag: 'Generator UI',
-    title: 'Custom text preview',
+    tag: "Generator UI",
+    title: "Custom text preview",
     description:
-      'Choose a style, type your text, and preview animated output before exporting. Generator frontend coming soon.'
-  }
+      "Choose a style, type your text, and preview animated output before exporting. Generator frontend coming soon.",
+  },
 ];
 
 export default async function HomePage() {
@@ -55,20 +56,30 @@ export default async function HomePage() {
 
       <section className="grid gap-4 lg:grid-cols-2">
         <Panel>
-          <p className="text-xs uppercase tracking-wider text-accent-cyan">What is MagicStix?</p>
-          <h2 className="mt-3 text-xl font-semibold text-text">A visual asset ecosystem.</h2>
+          <p className="text-xs uppercase tracking-wider text-accent-cyan">
+            What is MagicStix?
+          </p>
+          <h2 className="mt-3 text-xl font-semibold text-text">
+            A visual asset ecosystem.
+          </h2>
           <p className="mt-3 text-sm leading-relaxed text-muted">
-            MagicStix is a modular visual asset system. The bot pipeline generates stickers, animated letters, neon
-            signals, and overlay packs. This site is the public face of that ecosystem — preview, catalog, and future
-            generator frontend.
+            MagicStix is a modular visual asset system. The bot pipeline
+            generates stickers, animated letters, neon signals, and overlay
+            packs. This site is the public face of that ecosystem — preview,
+            catalog, and future generator frontend.
           </p>
         </Panel>
         <Panel variant="secondary">
-          <p className="text-xs uppercase tracking-wider text-accent-violet">Built for creators</p>
-          <h2 className="mt-3 text-xl font-semibold text-text">Ready for streams and chat.</h2>
+          <p className="text-xs uppercase tracking-wider text-accent-violet">
+            Built for creators
+          </p>
+          <h2 className="mt-3 text-xl font-semibold text-text">
+            Ready for streams and chat.
+          </h2>
           <p className="mt-3 text-sm leading-relaxed text-muted">
-            Stream overlays, chat stickers, animated name packs, DJ visuals, and emoji sets — all generated at quality
-            from a single pipeline and downloadable in GIF, WebM, WebP, and more.
+            Stream overlays, chat stickers, animated name packs, DJ visuals, and
+            emoji sets — all generated at quality from a single pipeline and
+            downloadable in GIF, WebM, WebP, and more.
           </p>
         </Panel>
       </section>

--- a/packages/ui/src/components/ArchitectureOverview.tsx
+++ b/packages/ui/src/components/ArchitectureOverview.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from 'react';
 
 import { motion } from "framer-motion";
 import { Panel } from "./Panel";

--- a/packages/ui/src/components/ArchitectureOverview.tsx
+++ b/packages/ui/src/components/ArchitectureOverview.tsx
@@ -42,9 +42,9 @@ export const ArchitectureOverview = () => (
         sticker experiences that feel alive.
       </p>
     </div>
-    <div className="grid gap-4 lg:grid-cols-3">
+    <ul className="grid gap-4 lg:grid-cols-3">
       {groups.map((group, gi) => (
-        <motion.div
+        <motion.li
           key={group.label}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -53,17 +53,17 @@ export const ArchitectureOverview = () => (
         >
           <Panel variant="secondary" className="h-full">
             <p className={`text-xs uppercase tracking-wider ${group.accent}`}>{group.label}</p>
-            <div className="mt-3 space-y-2">
+            <ul className="mt-3 space-y-2">
               {group.items.map((item) => (
-                <div key={item.name} className="rounded-lg border border-white/5 bg-background p-3">
+                <li key={item.name} className="rounded-lg border border-white/5 bg-background p-3">
                   <p className="text-xs font-medium text-accent-cyan">{item.name}</p>
                   <p className="mt-1 text-xs text-muted">{item.description}</p>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           </Panel>
-        </motion.div>
+        </motion.li>
       ))}
-    </div>
+    </ul>
   </section>
 );

--- a/packages/ui/src/components/ArchitectureOverview.tsx
+++ b/packages/ui/src/components/ArchitectureOverview.tsx
@@ -1,45 +1,78 @@
-'use client';
+"use client";
 
-import { motion } from 'framer-motion';
-import { Panel } from './Panel';
+import { motion } from "framer-motion";
+import { Panel } from "./Panel";
 
 const groups = [
   {
-    label: 'Create',
-    accent: 'text-accent-primary',
+    label: "Create",
+    accent: "text-accent-primary",
     items: [
-      { name: 'Fast pack setup', description: 'Build and preview sticker packs without a steep learning curve.' },
-      { name: 'Flexible mask styles', description: 'Choose from ready-to-use looks that match different communities.' }
-    ]
+      {
+        name: "Fast pack setup",
+        description:
+          "Build and preview sticker packs without a steep learning curve.",
+      },
+      {
+        name: "Flexible mask styles",
+        description:
+          "Choose from ready-to-use looks that match different communities.",
+      },
+    ],
   },
   {
-    label: 'Engage',
-    accent: 'text-accent-cyan',
+    label: "Engage",
+    accent: "text-accent-cyan",
     items: [
-      { name: 'Chat-ready output', description: 'Stickers are optimized so they look sharp where people use them.' },
-      { name: 'Interactive moments', description: 'Stickers can trigger playful responses that feel alive in chat.' },
-      { name: 'Telegram-first experience', description: 'Built for real group conversations from day one.' }
-    ]
+      {
+        name: "Chat-ready output",
+        description:
+          "Stickers are optimized so they look sharp where people use them.",
+      },
+      {
+        name: "Interactive moments",
+        description:
+          "Stickers can trigger playful responses that feel alive in chat.",
+      },
+      {
+        name: "Telegram-first experience",
+        description: "Built for real group conversations from day one.",
+      },
+    ],
   },
   {
-    label: 'Grow',
-    accent: 'text-accent-violet',
+    label: "Grow",
+    accent: "text-accent-violet",
     items: [
-      { name: 'Consistent quality', description: 'Use one workflow as your sticker catalog expands.' },
-      { name: 'Automation-ready', description: 'Add richer behaviors over time without rebuilding everything.' },
-      { name: 'Future platform support', description: 'Designed to extend to more chat surfaces as you scale.' }
-    ]
-  }
+      {
+        name: "Consistent quality",
+        description: "Use one workflow as your sticker catalog expands.",
+      },
+      {
+        name: "Automation-ready",
+        description:
+          "Add richer behaviors over time without rebuilding everything.",
+      },
+      {
+        name: "Future platform support",
+        description: "Designed to extend to more chat surfaces as you scale.",
+      },
+    ],
+  },
 ];
 
 export const ArchitectureOverview = () => (
   <section className="space-y-4">
     <div>
-      <p className="text-xs uppercase tracking-wider text-accent-cyan">The laboratory</p>
-      <h2 className="mt-2 text-2xl font-semibold text-text">Built for the full alchemy cycle</h2>
+      <p className="text-xs uppercase tracking-wider text-accent-cyan">
+        The laboratory
+      </p>
+      <h2 className="mt-2 text-2xl font-semibold text-text">
+        Built for the full alchemy cycle
+      </h2>
       <p className="mt-2 text-sm leading-relaxed text-muted">
-        The platform handles the transformation behind the scenes, so your focus stays on crafting
-        sticker experiences that feel alive.
+        The platform handles the transformation behind the scenes, so your focus
+        stays on crafting sticker experiences that feel alive.
       </p>
     </div>
     <ul className="grid gap-4 lg:grid-cols-3">
@@ -48,15 +81,22 @@ export const ArchitectureOverview = () => (
           key={group.label}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: '-60px' }}
+          viewport={{ once: true, margin: "-60px" }}
           transition={{ duration: 0.3, delay: gi * 0.07 }}
         >
           <Panel variant="secondary" className="h-full">
-            <p className={`text-xs uppercase tracking-wider ${group.accent}`}>{group.label}</p>
+            <p className={`text-xs uppercase tracking-wider ${group.accent}`}>
+              {group.label}
+            </p>
             <ul className="mt-3 space-y-2">
               {group.items.map((item) => (
-                <li key={item.name} className="rounded-lg border border-white/5 bg-background p-3">
-                  <p className="text-xs font-medium text-accent-cyan">{item.name}</p>
+                <li
+                  key={item.name}
+                  className="rounded-lg border border-white/5 bg-background p-3"
+                >
+                  <p className="text-xs font-medium text-accent-cyan">
+                    {item.name}
+                  </p>
                   <p className="mt-1 text-xs text-muted">{item.description}</p>
                 </li>
               ))}

--- a/packages/ui/src/components/HowItWorks.tsx
+++ b/packages/ui/src/components/HowItWorks.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from 'react';
 
 import { motion } from "framer-motion";
 

--- a/packages/ui/src/components/HowItWorks.tsx
+++ b/packages/ui/src/components/HowItWorks.tsx
@@ -1,35 +1,43 @@
-'use client';
+"use client";
 
-import { motion } from 'framer-motion';
+import { motion } from "framer-motion";
 
 const steps = [
   {
-    number: '△',
-    title: 'Feed your image',
-    description: 'Start with any image — photo, illustration, or artwork — and bring it into the alchemy lab.'
+    number: "△",
+    title: "Feed your image",
+    description:
+      "Start with any image — photo, illustration, or artwork — and bring it into the alchemy lab.",
   },
   {
-    number: '◯',
-    title: 'Choose a mask style',
-    description: 'Select the shape that transforms your image into a refined symbol with the right vibe.'
+    number: "◯",
+    title: "Choose a mask style",
+    description:
+      "Select the shape that transforms your image into a refined symbol with the right vibe.",
   },
   {
-    number: '✦',
-    title: 'Add an enchantment',
-    description: 'Optionally connect your sticker to a reply, reaction, or automation for living magic in chat.'
+    number: "✦",
+    title: "Add an enchantment",
+    description:
+      "Optionally connect your sticker to a reply, reaction, or automation for living magic in chat.",
   },
   {
-    number: '🪄',
-    title: 'Release into the world',
-    description: 'Publish to chat and watch your community wield stickers that feel alive and distinctly yours.'
-  }
+    number: "🪄",
+    title: "Release into the world",
+    description:
+      "Publish to chat and watch your community wield stickers that feel alive and distinctly yours.",
+  },
 ];
 
 export const HowItWorks = () => (
   <section id="how-it-works" className="space-y-4">
     <div>
-      <p className="text-xs uppercase tracking-wider text-accent-cyan">The Λlchemy</p>
-      <h2 className="mt-2 text-2xl font-semibold text-text">How the transformation works</h2>
+      <p className="text-xs uppercase tracking-wider text-accent-cyan">
+        The Λlchemy
+      </p>
+      <h2 className="mt-2 text-2xl font-semibold text-text">
+        How the transformation works
+      </h2>
       <p className="mt-2 text-sm leading-relaxed text-muted">
         Four steps from raw image to living magic in chat.
       </p>
@@ -40,13 +48,19 @@ export const HowItWorks = () => (
           key={step.number}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: '-80px' }}
+          viewport={{ once: true, margin: "-80px" }}
           transition={{ duration: 0.3, delay: i * 0.08 }}
           className="relative rounded-2xl border border-white/10 bg-panel p-5"
         >
-          <p className="text-3xl text-accent-primary/40" aria-hidden="true">{step.number}</p>
-          <h3 className="mt-2 text-base font-semibold text-text">{step.title}</h3>
-          <p className="mt-2 text-sm leading-relaxed text-muted">{step.description}</p>
+          <p className="text-3xl text-accent-primary/40" aria-hidden="true">
+            {step.number}
+          </p>
+          <h3 className="mt-2 text-base font-semibold text-text">
+            {step.title}
+          </h3>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            {step.description}
+          </p>
         </motion.li>
       ))}
     </ol>

--- a/packages/ui/src/components/HowItWorks.tsx
+++ b/packages/ui/src/components/HowItWorks.tsx
@@ -34,9 +34,9 @@ export const HowItWorks = () => (
         Four steps from raw image to living magic in chat.
       </p>
     </div>
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {steps.map((step, i) => (
-        <motion.div
+        <motion.li
           key={step.number}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -44,11 +44,11 @@ export const HowItWorks = () => (
           transition={{ duration: 0.3, delay: i * 0.08 }}
           className="relative rounded-2xl border border-white/10 bg-panel p-5"
         >
-          <p className="text-3xl text-accent-primary/40">{step.number}</p>
+          <p className="text-3xl text-accent-primary/40" aria-hidden="true">{step.number}</p>
           <h3 className="mt-2 text-base font-semibold text-text">{step.title}</h3>
           <p className="mt-2 text-sm leading-relaxed text-muted">{step.description}</p>
-        </motion.div>
+        </motion.li>
       ))}
-    </div>
+    </ol>
   </section>
 );

--- a/packages/ui/src/components/Roadmap.tsx
+++ b/packages/ui/src/components/Roadmap.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from 'react';
 
 import { motion } from "framer-motion";
 

--- a/packages/ui/src/components/Roadmap.tsx
+++ b/packages/ui/src/components/Roadmap.tsx
@@ -74,7 +74,7 @@ export const Roadmap = () => (
         often.
       </p>
     </div>
-    <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {phases.map((phase, i) => (
         <motion.li
           key={phase.phase}

--- a/packages/ui/src/components/Roadmap.tsx
+++ b/packages/ui/src/components/Roadmap.tsx
@@ -48,9 +48,9 @@ export const Roadmap = () => (
         STIX MΛGIC is evolving in clear stages so creators get value early and often.
       </p>
     </div>
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {phases.map((phase, i) => (
-        <motion.div
+        <motion.li
           key={phase.phase}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -69,13 +69,13 @@ export const Roadmap = () => (
           <ul className="mt-3 space-y-1">
             {phase.items.map((item) => (
               <li key={item} className="flex items-start gap-2 text-xs text-muted">
-                <span className="mt-px text-accent-cyan">·</span>
+                <span className="mt-px text-accent-cyan" aria-hidden="true">·</span>
                 {item}
               </li>
             ))}
           </ul>
-        </motion.div>
+        </motion.li>
       ))}
-    </div>
+    </ul>
   </section>
 );

--- a/packages/ui/src/components/Roadmap.tsx
+++ b/packages/ui/src/components/Roadmap.tsx
@@ -1,51 +1,76 @@
-'use client';
+"use client";
 
-import { motion } from 'framer-motion';
+import { motion } from "framer-motion";
 
 const phases = [
   {
-    phase: 'Available now',
-    status: 'complete',
-    items: ['Sticker pack creation flow', 'Core mask catalog', 'Telegram-ready publishing path', 'Live project updates']
+    phase: "Available now",
+    status: "complete",
+    items: [
+      "Sticker pack creation flow",
+      "Core mask catalog",
+      "Telegram-ready publishing path",
+      "Live project updates",
+    ],
   },
   {
-    phase: 'In progress',
-    status: 'active',
-    items: ['Smoother publishing UX', 'More polished creator controls', 'Expanded interaction options', 'Faster feedback loop']
+    phase: "In progress",
+    status: "active",
+    items: [
+      "Smoother publishing UX",
+      "More polished creator controls",
+      "Expanded interaction options",
+      "Faster feedback loop",
+    ],
   },
   {
-    phase: 'Coming next',
-    status: 'upcoming',
-    items: ['Ready-made interaction templates', 'Deeper bot behavior options', 'Improved reliability at scale', 'Better creator insights']
+    phase: "Coming next",
+    status: "upcoming",
+    items: [
+      "Ready-made interaction templates",
+      "Deeper bot behavior options",
+      "Improved reliability at scale",
+      "Better creator insights",
+    ],
   },
   {
-    phase: 'Future',
-    status: 'future',
-    items: ['Support for more chat platforms', 'Advanced visual mask effects', 'Team workflows and collaboration', 'Marketplace-style discovery']
-  }
+    phase: "Future",
+    status: "future",
+    items: [
+      "Support for more chat platforms",
+      "Advanced visual mask effects",
+      "Team workflows and collaboration",
+      "Marketplace-style discovery",
+    ],
+  },
 ];
 
 const statusStyles: Record<string, string> = {
-  complete: 'text-accent-cyan border-accent-cyan/30 bg-accent-cyan/10',
-  active: 'text-accent-primary border-accent-primary/30 bg-accent-primary/10',
-  upcoming: 'text-accent-violet border-accent-violet/30 bg-accent-violet/10',
-  future: 'text-muted border-white/10 bg-white/5'
+  complete: "text-accent-cyan border-accent-cyan/30 bg-accent-cyan/10",
+  active: "text-accent-primary border-accent-primary/30 bg-accent-primary/10",
+  upcoming: "text-accent-violet border-accent-violet/30 bg-accent-violet/10",
+  future: "text-muted border-white/10 bg-white/5",
 };
 
 const statusLabels: Record<string, string> = {
-  complete: 'Complete',
-  active: 'In progress',
-  upcoming: 'Upcoming',
-  future: 'Future'
+  complete: "Complete",
+  active: "In progress",
+  upcoming: "Upcoming",
+  future: "Future",
 };
 
 export const Roadmap = () => (
   <section className="space-y-4">
     <div>
-      <p className="text-xs uppercase tracking-wider text-accent-cyan">The journey</p>
-      <h2 className="mt-2 text-2xl font-semibold text-text">What’s forging over time</h2>
+      <p className="text-xs uppercase tracking-wider text-accent-cyan">
+        The journey
+      </p>
+      <h2 className="mt-2 text-2xl font-semibold text-text">
+        What’s forging over time
+      </h2>
       <p className="mt-2 text-sm leading-relaxed text-muted">
-        STIX MΛGIC is evolving in clear stages so creators get value early and often.
+        STIX MΛGIC is evolving in clear stages so creators get value early and
+        often.
       </p>
     </div>
     <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -54,7 +79,7 @@ export const Roadmap = () => (
           key={phase.phase}
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: '-80px' }}
+          viewport={{ once: true, margin: "-80px" }}
           transition={{ duration: 0.3, delay: i * 0.06 }}
           className="rounded-2xl border border-white/10 bg-panel p-5"
         >
@@ -68,8 +93,13 @@ export const Roadmap = () => (
           </div>
           <ul className="mt-3 space-y-1">
             {phase.items.map((item) => (
-              <li key={item} className="flex items-start gap-2 text-xs text-muted">
-                <span className="mt-px text-accent-cyan" aria-hidden="true">·</span>
+              <li
+                key={item}
+                className="flex items-start gap-2 text-xs text-muted"
+              >
+                <span className="mt-px text-accent-cyan" aria-hidden="true">
+                  ·
+                </span>
                 {item}
               </li>
             ))}


### PR DESCRIPTION
🎨 Palette: Semantic List Wrappers for Grid Components

**💡 What:** 
Updated mapped grid components (`ArchitectureOverview`, `HowItWorks`, and `Roadmap`) to use semantic list wrappers (`<ul>`, `<ol>`, and `<li>`) instead of generic `<div>` tags. Added `aria-hidden="true"` to visual decorative elements within these lists (step numbers, separating dots).

**🎯 Why:** 
Screen readers use semantic list markup to understand structure and announce the number of items. Using generic `<div>` tags removes this crucial context, leaving users unsure of how many steps or items exist in a sequence. Additionally, hiding purely decorative elements reduces noise for screen reader users.

**♿ Accessibility:** 
Improves structural semantics and screen reader announcements for the affected components without altering the visual design. Tested using standard `pnpm typecheck`, `pnpm lint`, and `pnpm test` workflows.

---
*PR created automatically by Jules for task [1386773737319075983](https://jules.google.com/task/1386773737319075983) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved semantic HTML structure across the UI by switching animated card layouts to list-based structures (`ul`/`li` and `ol` for step/phase sequences).
  * Refreshed homepage and UI markup formatting for consistency, without changing what’s displayed.
* **Accessibility**
  * Marked decorative or non-informative elements (such as step numbers and separators) as `aria-hidden` to better support assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->