### PR TITLE
🎨 Palette: Hide decorative background elements from screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-06-19 - Accessible "Coming Soon" Tabs/Buttons
 **Learning:** When implementing 'Coming Soon' tabs or similar inactive buttons, using the native `disabled` attribute completely removes them from the keyboard navigation sequence. This prevents screen reader users and keyboard navigators from discovering what features are upcoming.
 **Action:** Always use `aria-disabled="true"` instead of the native `disabled` attribute for these types of elements. Ensure they remain focusable and continue to use CSS utility classes (e.g., `opacity-50 cursor-not-allowed hover:text-muted/50`) to visually simulate the disabled state.
+
+## 2024-12-16 - Decorative Elements Accessibility
+**Learning:** Decorative background elements, such as glows, blurs, and ASCII visual separators (e.g., '✦ ───────── ✦'), that serve no semantic or structural purpose can create significant noise for screen reader users if left exposed in the accessibility tree. They are often announced generically (like 'span') or read out as literal punctuation, causing confusion.
+**Action:** Always ensure that purely visual, non-informative elements (like decorative spans, background gradients, SVG shapes without meaning, and ASCII art) are explicitly hidden from assistive technologies by applying `aria-hidden="true"`.

--- a/packages/ui/src/components/CTASection.tsx
+++ b/packages/ui/src/components/CTASection.tsx
@@ -11,12 +11,12 @@ export const CTASection = () => (
     transition={{ duration: 0.45 }}
     className="relative overflow-hidden rounded-3xl border border-accent-primary/20 bg-panel p-10 text-center"
   >
-    <div className="pointer-events-none absolute inset-0">
+    <div className="pointer-events-none absolute inset-0" aria-hidden="true">
       <div className="absolute left-1/2 top-0 h-48 w-64 -translate-x-1/2 rounded-full bg-accent-primary/15 blur-3xl" />
       <div className="absolute bottom-0 right-0 h-40 w-56 rounded-full bg-accent-violet/15 blur-3xl" />
     </div>
     <div className="relative z-10">
-      <p className="text-xs uppercase tracking-widest text-accent-cyan/70">✦ ───────── ✦</p>
+      <p className="text-xs uppercase tracking-widest text-accent-cyan/70" aria-hidden="true">✦ ───────── ✦</p>
       <p className="mt-4 text-xs uppercase tracking-wider text-accent-cyan">Enter the PØRTAL</p>
       <h2 className="mt-4 text-3xl font-semibold text-text">Ready to begin your sticker alchemy?</h2>
       <p className="mx-auto mt-4 max-w-xl text-sm leading-relaxed text-muted">
@@ -37,7 +37,7 @@ export const CTASection = () => (
           Follow the Build
         </a>
       </div>
-      <p className="mt-10 text-xs text-accent-cyan/50 tracking-widest">△ ── ◯ ── ✦ ── ◯ ── △</p>
+      <p className="mt-10 text-xs text-accent-cyan/50 tracking-widest" aria-hidden="true">△ ── ◯ ── ✦ ── ◯ ── △</p>
     </div>
   </motion.section>
 );

--- a/packages/ui/src/components/Hero.tsx
+++ b/packages/ui/src/components/Hero.tsx
@@ -29,12 +29,14 @@ export const Hero = ({
 }: HeroProps) => (
   <section className="relative overflow-hidden rounded-3xl border border-accent-primary/20 bg-panel px-8 py-14">
     <motion.div
+      aria-hidden="true"
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.45 }}
       className="absolute -left-16 -top-16 h-52 w-52 rounded-full bg-accent-cyan/20 blur-3xl"
     />
     <motion.div
+      aria-hidden="true"
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.45, delay: 0.05 }}

--- a/packages/ui/src/components/MaskHeroPreview.tsx
+++ b/packages/ui/src/components/MaskHeroPreview.tsx
@@ -18,7 +18,7 @@ interface MaskHeroPreviewProps {
 
 export const MaskHeroPreview = ({ selectedMask }: MaskHeroPreviewProps) => (
   <div className="relative rounded-2xl border border-white/10 bg-panel p-8">
-    <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-accent-cyan/10 via-transparent to-accent-violet/15" />
+    <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-accent-cyan/10 via-transparent to-accent-violet/15" aria-hidden="true" />
     <div className="relative grid gap-5 md:grid-cols-[1fr_1.2fr] md:items-center">
       <svg viewBox="0 0 128 128" className="mx-auto h-44 w-44 text-accent-primary" fill="currentColor" aria-hidden>
         <path d={maskPaths[selectedMask.id]} />

--- a/packages/ui/src/components/Roadmap.tsx
+++ b/packages/ui/src/components/Roadmap.tsx
@@ -107,6 +107,6 @@ export const Roadmap = () => (
           </ul>
         </motion.li>
       ))}
-    </ul>
+    </ol>
   </section>
 );


### PR DESCRIPTION
Added `aria-hidden="true"` to purely decorative background elements in `@stixmagic/ui` components (like `Hero`, `MaskHeroPreview`, and `CTASection`) as well as purely visual ASCII separators (like '✦ ───────── ✦'). These elements were previously exposed in the accessibility tree, causing screen readers to announce meaningless spans or punctuation, which creates unnecessary noise for users navigating via keyboard and assistive technology.

Also added a journal entry in `.Jules/palette.md` to document this accessibility pattern for future reference, and resolved a minor semantic tag mismatch (`<ul>` to `<ol>`) in `Roadmap.tsx`.

---
*PR created automatically by Jules for task [17490236131551059611](https://jules.google.com/task/17490236131551059611) started by @FriskyDevelopments*