### PR TITLE
🎨 Palette: Add image role to AssetPreview fallbacks

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -8,7 +8,7 @@ const useBasePath = isGitHubPagesBuild && repoName.length > 0 && !isUserOrOrgSit
 const basePath = useBasePath ? `/${repoName}` : '';
 
 const nextConfig = {
-  output: process.env.GITHUB_ACTIONS === 'true' || process.env.CF_PAGES === '1' ? 'export' : undefined,
+  output: process.env.GITHUB_ACTIONS === 'true' ? 'export' : undefined,
   trailingSlash: true,
   images: {
     unoptimized: true

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -8,7 +8,7 @@ const useBasePath = isGitHubPagesBuild && repoName.length > 0 && !isUserOrOrgSit
 const basePath = useBasePath ? `/${repoName}` : '';
 
 const nextConfig = {
-  output: process.env.GITHUB_ACTIONS === 'true' ? 'export' : undefined,
+  output: process.env.GITHUB_ACTIONS === 'true' || process.env.CF_PAGES === '1' ? 'export' : undefined,
   trailingSlash: true,
   images: {
     unoptimized: true

--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,7 +23,7 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending" role="img">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
@@ -37,6 +37,7 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
       <div
         className="flex h-full w-full flex-col items-center justify-center gap-1"
         aria-label="Preview unavailable"
+        role="img"
       >
         <span className="text-base text-muted/40" aria-hidden="true">—</span>
         <span className="text-[10px] uppercase tracking-wide text-muted/40">Unavailable</span>


### PR DESCRIPTION
💡 **What:** Added `role="img"` to the `pending` and `failed` fallback states of the `AssetPreview` component.
🎯 **Why:** To improve accessibility. The fallback states were using `div` elements with `aria-label`, but without a specific role, screen readers might not announce them consistently as image substitutes.
📸 **Before/After:** Not a visual change. Screen readers will now announce the pending/failed states as "Image, Preview pending" or "Image, Preview unavailable".
♿ **Accessibility:** Fixes a minor issue where visual image placeholders lacked appropriate semantic roles.

---
*PR created automatically by Jules for task [1245143752831775214](https://jules.google.com/task/1245143752831775214) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for asset previews by marking pending and failed preview containers as images for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->