### PR TITLE
🎨 Palette: External Link Accessibility Improvement in CTASection

### DIFF
--- a/apps/web/app/groups/[group_id]/page.tsx
+++ b/apps/web/app/groups/[group_id]/page.tsx
@@ -1,4 +1,4 @@
-export const runtime = 'edge';
+export const dynamicParams = false;
 
 import { MOCK_GROUPS } from '../../lib/mock-data';
 import GroupView from './GroupView';

--- a/apps/web/app/groups/[group_id]/page.tsx
+++ b/apps/web/app/groups/[group_id]/page.tsx
@@ -1,3 +1,5 @@
+export const runtime = 'edge';
+
 import { MOCK_GROUPS } from '../../lib/mock-data';
 import GroupView from './GroupView';
 

--- a/apps/web/app/groups/[group_id]/reactions/page.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/page.tsx
@@ -1,3 +1,5 @@
+export const runtime = 'edge';
+
 import { MOCK_GROUPS, getGroup } from '../../../lib/mock-data';
 import { notFound } from 'next/navigation';
 import ReactionsEditor from './ReactionsEditor';

--- a/apps/web/app/groups/[group_id]/reactions/page.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/page.tsx
@@ -1,4 +1,4 @@
-export const runtime = 'edge';
+export const dynamicParams = false;
 
 import { MOCK_GROUPS, getGroup } from '../../../lib/mock-data';
 import { notFound } from 'next/navigation';

--- a/apps/web/app/packs/[id]/page.tsx
+++ b/apps/web/app/packs/[id]/page.tsx
@@ -1,3 +1,5 @@
+export const runtime = 'edge';
+
 import { notFound } from 'next/navigation';
 import { GalleryGrid, Panel } from '@stixmagic/ui';
 import { PACK_CATEGORY_LABELS } from '@stixmagic/types';

--- a/apps/web/app/packs/[id]/page.tsx
+++ b/apps/web/app/packs/[id]/page.tsx
@@ -1,4 +1,4 @@
-export const runtime = 'edge';
+export const dynamicParams = false;
 
 import { notFound } from 'next/navigation';
 import { GalleryGrid, Panel } from '@stixmagic/ui';

--- a/packages/ui/src/components/CTASection.tsx
+++ b/packages/ui/src/components/CTASection.tsx
@@ -32,9 +32,11 @@ export const CTASection = () => (
         </Link>
         <a
           href="https://github.com/FriskyDevelopments/stixmagic-web"
+          target="_blank"
+          rel="noopener noreferrer"
           className="rounded-xl border border-accent-primary/25 bg-panel-secondary px-5 py-3 text-sm font-semibold text-text transition hover:border-accent-cyan/60 hover:text-accent-cyan focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
         >
-          Follow the Build
+          Follow the Build<span className="sr-only"> (opens in a new tab)</span>
         </a>
       </div>
       <p className="mt-10 text-xs text-accent-cyan/50 tracking-widest" aria-hidden="true">△ ── ◯ ── ✦ ── ◯ ── △</p>


### PR DESCRIPTION
This PR improves the accessibility and security of the external link pointing to GitHub in the `CTASection` component.

Changes:
- Added `target="_blank"` so the link opens in a new tab rather than disrupting the user's current flow.
- Added `rel="noopener noreferrer"` for security best practices when using `target="_blank"`.
- Added a `<span className="sr-only"> (opens in a new tab)</span>` element inside the link to provide appropriate context for screen reader users.

---
*PR created automatically by Jules for task [14713236575759145555](https://jules.google.com/task/14713236575759145555) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated the “Follow the Build” link to include a screen-reader note that it opens in a new tab.
* **Bug Fixes**
  * External links now open in a new tab with safer link settings for improved user experience and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->