### PR TITLE
🎨 Palette: Add screen reader context to status badges

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -60,3 +60,7 @@
 ## 2024-12-16 - Screen Reader Context for Floating Badges and Tags
 **Learning:** Beautiful floating badges (like "Premium", "GIF", or categories) and visual tag clouds often lack context for screen readers. A badge that just reads "GIF" or "Premium" can be confusing without knowing what it applies to. Additionally, tags laid out in generic `<div>` containers are not announced as a list of items, making them hard to parse sequentially.
 **Action:** Always add visually hidden context to standalone badges (e.g., `<span className="sr-only">Format: </span>GIF`). Convert tag clouds and format lists to semantic `<ul>` structures with `aria-label` (e.g., `<ul aria-label="Tags">`) and `<li>` items to ensure screen readers announce them properly as lists.
+
+## 2024-07-16 - Screen Reader Context for Status Badges
+**Learning:** Floating status badges (e.g., "soon", "Featured", "In progress") can be confusing to screen reader users without context. For instance, just hearing "soon" or "Featured" without knowing it represents a status can be disorienting.
+**Action:** When creating status badges or similar indicators, always prefix the text with a visually hidden context string using `<span className="sr-only">Status: </span>` to ensure screen readers provide the correct meaning.

--- a/packages/ui/src/components/GeneratorScaffold.tsx
+++ b/packages/ui/src/components/GeneratorScaffold.tsx
@@ -41,6 +41,7 @@ export const GeneratorScaffold = ({ steps }: GeneratorScaffoldProps) => {
             {step.label}
             {step.comingSoon && (
               <span className="rounded-full bg-accent-violet/20 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-accent-violet">
+                <span className="sr-only">Status: </span>
                 soon
               </span>
             )}

--- a/packages/ui/src/components/PackCard.tsx
+++ b/packages/ui/src/components/PackCard.tsx
@@ -29,6 +29,7 @@ export const PackCard = ({ pack, className }: PackCardProps) => (
       <AssetPreview url={pack.previewUrl} alt={pack.name} imageClassName="h-full w-full object-cover" />
       {pack.featured && (
         <span className="absolute right-3 top-3 rounded-full bg-accent-primary px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-text">
+          <span className="sr-only">Status: </span>
           Featured
         </span>
       )}

--- a/packages/ui/src/components/Roadmap.tsx
+++ b/packages/ui/src/components/Roadmap.tsx
@@ -89,6 +89,7 @@ export const Roadmap = () => (
             <span
               className={`shrink-0 rounded-full border px-2.5 py-0.5 text-[10px] uppercase tracking-wide ${statusStyles[phase.status]}`}
             >
+              <span className="sr-only">Status: </span>
               {statusLabels[phase.status]}
             </span>
           </div>


### PR DESCRIPTION
This PR adds screen reader context to floating status badges across multiple UI components.

- `Roadmap`: Added "Status: " context before the phase status labels.
- `PackCard`: Added "Status: " context before the "Featured" badge.
- `GeneratorScaffold`: Added "Status: " context before the "soon" badge.

This ensures that screen reader users hear "Status: soon" instead of just "soon" out of context, making the interface more intuitive and accessible.

---
*PR created automatically by Jules for task [3876218166147984683](https://jules.google.com/task/3876218166147984683) started by @FriskyDevelopments*