### PR TITLE
🎨 Palette: Improve accessibility of AssetPreview placeholders

### DIFF
--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,11 +23,15 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div
+        className="flex h-full w-full flex-col items-center justify-center gap-2"
+        role="img"
+        aria-label={`Preview pending for ${alt}`}
+      >
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
-        <span className="text-[10px] uppercase tracking-wide text-muted/50">Preview pending</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/50" aria-hidden="true">Preview pending</span>
       </div>
     );
   }
@@ -36,10 +40,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
     return (
       <div
         className="flex h-full w-full flex-col items-center justify-center gap-1"
-        aria-label="Preview unavailable"
+        role="img"
+        aria-label={`Preview unavailable for ${alt}`}
       >
         <span className="text-base text-muted/40" aria-hidden="true">—</span>
-        <span className="text-[10px] uppercase tracking-wide text-muted/40">Unavailable</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/40" aria-hidden="true">Unavailable</span>
       </div>
     );
   }
@@ -51,7 +56,7 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
           <div
             className="h-5 w-5 animate-spin rounded-full border-2 border-accent-primary/20 border-t-accent-primary"
             role="status"
-            aria-label="Loading preview"
+            aria-label={`Loading preview for ${alt}`}
           />
         </div>
       )}


### PR DESCRIPTION
This PR improves the accessibility of the `AssetPreview` component's placeholder and loading states. By ensuring screen readers announce the placeholders as images and providing contextual labels based on the `alt` text, users relying on assistive technologies get a much clearer understanding of the UI's status. It also hides redundant visible text from screen readers to reduce noise.

---
*PR created automatically by Jules for task [9095028697831256251](https://jules.google.com/task/9095028697831256251) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader labels for asset preview loading, pending, and unavailable states.
  * Added descriptive labels based on the asset’s alternative text.
  * Hidden redundant visual status text from assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->