### PR TITLE
🎨 Palette: [UX improvement] Add ARIA semantics to AssetPreview placeholders

### DIFF
--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,11 +23,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2" role="img" aria-label="Preview pending">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
-        <span className="text-[10px] uppercase tracking-wide text-muted/50">Preview pending</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/50" aria-hidden="true">Preview pending</span>
       </div>
     );
   }
@@ -36,10 +36,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
     return (
       <div
         className="flex h-full w-full flex-col items-center justify-center gap-1"
+        role="img"
         aria-label="Preview unavailable"
       >
         <span className="text-base text-muted/40" aria-hidden="true">—</span>
-        <span className="text-[10px] uppercase tracking-wide text-muted/40">Unavailable</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/40" aria-hidden="true">Unavailable</span>
       </div>
     );
   }


### PR DESCRIPTION
💡 **What:** Added `role="img"` to placeholder states in `AssetPreview` and hid internal text spans from screen readers using `aria-hidden="true"`.
🎯 **Why:** Previously, the placeholder elements were generic `div`s with `aria-label`s, but they also contained visible text. This caused screen readers to redundantly announce both the `aria-label` on the wrapper and the generic text span inside it. By giving the container an explicit `img` role and hiding the text, we provide a much cleaner, singular announcement (e.g., "Preview pending, image").
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Prevents redundant and noisy screen reader announcements for asset preview placeholder states.

---
*PR created automatically by Jules for task [3751689590526562092](https://jules.google.com/task/3751689590526562092) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen-reader announcements for pending and unavailable asset previews.
  * Added descriptive labels and reduced redundant spoken content in preview status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->