### PR TITLE
🎨 Palette: Improve screen reader accessibility by hiding decorative elements and clarifying badges

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -116,7 +116,7 @@ export default function DashboardPage() {
         ) : groups.length === 0 ? (
           <Panel variant="secondary">
             <div className="py-6 text-center">
-              <p className="text-2xl">🪄</p>
+              <p className="text-2xl" aria-hidden="true">🪄</p>
               <p className="mt-3 text-sm font-medium text-text">No groups connected yet</p>
               <p className="mt-1 text-sm text-muted">
                 Add the Stix Magic bot to your Telegram group and give it admin rights to see it here.
@@ -145,6 +145,7 @@ export default function DashboardPage() {
                             : 'bg-muted/10 text-muted'
                         }`}
                       >
+                        <span className="sr-only">Status: </span>
                         {group.settings.reactionsEnabled ? 'Active' : 'Paused'}
                       </span>
                     </div>

--- a/apps/web/app/gallery/page.tsx
+++ b/apps/web/app/gallery/page.tsx
@@ -51,7 +51,7 @@ export default async function GalleryPage() {
         {assets.length === 0 ? (
           <Panel variant="secondary">
             <div className="py-6 text-center">
-              <p className="text-2xl">🖼️</p>
+              <p className="text-2xl" aria-hidden="true">🖼️</p>
               <p className="mt-3 text-sm font-medium text-text">No previews available</p>
               <p className="mt-1 text-sm text-muted">
                 Preview assets will appear here once the pipeline manifest is populated.

--- a/apps/web/app/groups/[group_id]/GroupView.tsx
+++ b/apps/web/app/groups/[group_id]/GroupView.tsx
@@ -86,6 +86,7 @@ export default function GroupView({ groupId }: Props) {
                 : 'bg-muted/10 text-muted'
             }`}
           >
+            <span className="sr-only">Status: </span>
             {group.settings.reactionsEnabled ? 'Reactions Active' : 'Reactions Paused'}
           </span>
         </div>
@@ -220,6 +221,7 @@ export default function GroupView({ groupId }: Props) {
                     rule.enabled ? 'bg-accent-teal/15 text-accent-teal' : 'bg-muted/10 text-muted'
                   }`}
                 >
+                  <span className="sr-only">Status: </span>
                   {rule.enabled ? 'Active' : 'Paused'}
                 </span>
                 <Link

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -531,7 +531,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
       ) : rules.length === 0 && !showForm ? (
         <Panel variant="secondary">
           <div className="py-6 text-center">
-            <p className="text-2xl">✨</p>
+            <p className="text-2xl" aria-hidden="true">✨</p>
             <p className="mt-3 text-sm font-medium text-text">No reaction rules yet</p>
             <p className="mt-1 text-sm text-muted">
               Create your first rule to start automating responses in {groupName}.
@@ -569,6 +569,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                             : 'bg-muted/10 text-muted'
                         }`}
                       >
+                        <span className="sr-only">Status: </span>
                         {rule.enabled ? 'Active' : 'Paused'}
                       </span>
                     </div>

--- a/apps/web/app/groups/page.tsx
+++ b/apps/web/app/groups/page.tsx
@@ -87,7 +87,7 @@ export default function GroupsPage() {
       ) : groups.length === 0 ? (
         <Panel variant="secondary">
           <div className="py-6 text-center">
-            <p className="text-2xl">🪄</p>
+            <p className="text-2xl" aria-hidden="true">🪄</p>
             <p className="mt-3 text-sm font-medium text-text">No groups connected yet</p>
             <p className="mt-1 text-sm text-muted">
               Follow the instructions below to add the bot to your group and grant admin rights.
@@ -116,6 +116,7 @@ export default function GroupsPage() {
                           : 'bg-muted/10 text-muted'
                       }`}
                     >
+                      <span className="sr-only">Status: </span>
                       {group.settings.reactionsEnabled ? 'Active' : 'Paused'}
                     </span>
                   </div>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
     <html lang="en">
       <body className={inter.className}>
         <div className="relative min-h-screen bg-background">
-          <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
             <div className="stix-float absolute -left-24 top-8 h-64 w-64 rounded-full bg-accent-cyan/20 blur-3xl" />
             <div className="stix-float-reverse absolute right-0 top-40 h-56 w-56 rounded-full bg-accent-violet/25 blur-3xl" />
             <div className="stix-float absolute left-1/2 top-20 h-44 w-44 -translate-x-1/2 rounded-full bg-accent-primary/20 blur-3xl" />
@@ -32,7 +32,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           <header className="sticky top-0 z-20 border-b border-accent-primary/15 bg-background/70 backdrop-blur-md">
             <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
               <Link href="/" className="inline-flex items-center gap-2 rounded-lg p-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 hover:bg-white/5">
-                <span className="text-xl drop-shadow-[0_0_10px_rgba(0,212,255,0.6)]">🪄</span>
+                <span className="text-xl drop-shadow-[0_0_10px_rgba(0,212,255,0.6)]" aria-hidden="true">🪄</span>
                 <span className="bg-gradient-to-r from-accent-cyan via-accent-indigo to-accent-violet bg-clip-text text-lg font-extrabold tracking-[0.08em] text-transparent">
                   MagicStix
                 </span>
@@ -50,7 +50,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           </header>
           <main id="main-content" className="relative z-10 mx-auto w-full max-w-6xl px-6 pb-16 pt-6">{children}</main>
           <footer className="relative z-10 border-t border-accent-primary/10 py-10 text-center">
-            <p className="text-xs text-accent-cyan/50 tracking-widest uppercase">△ ── ◯ ── ✦ ── ◯ ── △</p>
+            <p className="text-xs text-accent-cyan/50 tracking-widest uppercase" aria-hidden="true">△ ── ◯ ── ✦ ── ◯ ── △</p>
             <p className="mt-4 text-sm text-muted">
               🐾 Forged with a Frisky Paw and a daring heart.
             </p>
@@ -59,7 +59,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
               <span className="bg-gradient-to-r from-accent-cyan via-accent-indigo to-accent-violet bg-clip-text font-semibold text-transparent">
                 MagicStix
               </span>{' '}
-              to life ✨
+              to life <span aria-hidden="true">✨</span>
             </p>
             <p className="mt-2 text-xs text-muted/60">— FriskyDevelopments</p>
           </footer>

--- a/apps/web/app/packs/page.tsx
+++ b/apps/web/app/packs/page.tsx
@@ -54,7 +54,7 @@ export default async function PacksPage() {
         {packs.length === 0 ? (
           <Panel variant="secondary">
             <div className="py-6 text-center">
-              <p className="text-2xl">📦</p>
+              <p className="text-2xl" aria-hidden="true">📦</p>
               <p className="mt-3 text-sm font-medium text-text">No packs available</p>
               <p className="mt-1 text-sm text-muted">
                 Asset packs will appear here once the pipeline manifest is populated.


### PR DESCRIPTION
Implements a UX micro-improvement focused on accessibility for screen reader users.

**Changes:**
1. Added `aria-hidden="true"` to purely decorative visual elements (background blurs, ASCII art strings in the footer, and emojis used in empty state illustrations) across `apps/web/app/layout.tsx`, `dashboard/page.tsx`, `groups/page.tsx`, `reactions/ReactionsEditor.tsx`, `packs/page.tsx`, and `gallery/page.tsx`.
2. Added `<span className="sr-only">Status: </span>` to floating status badges that indicate if reactions or rules are "Active" or "Paused". Without this, screen readers just read "Active", which lacks context.

**Verification:**
- Validated via `pnpm lint`, `pnpm build`, and `pnpm test`.
- Playwright screenshot/video recording confirmed no visual regressions.
- Code review validated the approach.

---
*PR created automatically by Jules for task [8882847205707330856](https://jules.google.com/task/8882847205707330856) started by @FriskyDevelopments*