### PR TITLE
🎨 Palette: Make rule toggle loading state specific to the clicked rule

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,7 @@
 ## 2024-07-16 - Screen Reader Context for Status Badges
 **Learning:** Floating status badges (e.g., "soon", "Featured", "In progress") can be confusing to screen reader users without context. For instance, just hearing "soon" or "Featured" without knowing it represents a status can be disorienting.
 **Action:** When creating status badges or similar indicators, always prefix the text with a visually hidden context string using `<span className="sr-only">Status: </span>` to ensure screen readers provide the correct meaning.
+
+## 2024-12-16 - Item-Specific Loading States in Dynamic Lists
+**Learning:** When displaying dynamic lists where items can be individually toggled or acted upon (like activating a reaction rule), using a single global `loading` or `toggling` boolean state forces all items in the list to visually disable and show loading indicators when any single item is clicked. This creates a confusing "locked up" feel for the entire UI, even though only one item is actually processing.
+**Action:** For item-specific actions in mapped lists, always use a Set of IDs (e.g., `togglingIds: Set<string>`) rather than a global boolean or a single ID string. This ensures only active items are disabled/show loading spinners and supports concurrent toggling without race conditions.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,7 @@
 ## 2024-07-16 - Screen Reader Context for Status Badges
 **Learning:** Floating status badges (e.g., "soon", "Featured", "In progress") can be confusing to screen reader users without context. For instance, just hearing "soon" or "Featured" without knowing it represents a status can be disorienting.
 **Action:** When creating status badges or similar indicators, always prefix the text with a visually hidden context string using `<span className="sr-only">Status: </span>` to ensure screen readers provide the correct meaning.
+
+## 2024-12-16 - Item-Specific Loading States in Dynamic Lists
+**Learning:** When displaying dynamic lists where items can be individually toggled or acted upon (like activating a reaction rule), using a single global `loading` or `toggling` boolean state forces all items in the list to visually disable and show loading indicators when any single item is clicked. This creates a confusing "locked up" feel for the entire UI, even though only one item is actually processing.
+**Action:** For item-specific actions in mapped lists, always use an ID-based loading state (e.g., `togglingId: string | null`) rather than a global boolean to ensure only the active item is disabled and displays a loading spinner, leaving the rest of the list interactive and visually distinct.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,7 +64,3 @@
 ## 2024-07-16 - Screen Reader Context for Status Badges
 **Learning:** Floating status badges (e.g., "soon", "Featured", "In progress") can be confusing to screen reader users without context. For instance, just hearing "soon" or "Featured" without knowing it represents a status can be disorienting.
 **Action:** When creating status badges or similar indicators, always prefix the text with a visually hidden context string using `<span className="sr-only">Status: </span>` to ensure screen readers provide the correct meaning.
-
-## 2024-12-16 - Item-Specific Loading States in Dynamic Lists
-**Learning:** When displaying dynamic lists where items can be individually toggled or acted upon (like activating a reaction rule), using a single global `loading` or `toggling` boolean state forces all items in the list to visually disable and show loading indicators when any single item is clicked. This creates a confusing "locked up" feel for the entire UI, even though only one item is actually processing.
-**Action:** For item-specific actions in mapped lists, always use an ID-based loading state (e.g., `togglingId: string | null`) rather than a global boolean to ensure only the active item is disabled and displays a loading spinner, leaving the rest of the list interactive and visually distinct.

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -79,7 +79,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
-  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
   const [testResult, setTestResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -146,7 +146,11 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   const handleToggle = async (id: string, current: boolean) => {
     const previousRules = rules;
     setRules((prev) => prev.map((r) => (r.id === id ? { ...r, enabled: !current } : r)));
-    setTogglingId(id);
+    setTogglingIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
     try {
       await toggleRule(groupId, id, !current);
     } catch (err) {
@@ -154,7 +158,11 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError(`Failed to toggle rule: ${message}`);
     } finally {
-      setTogglingId(null);
+      setTogglingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
     }
   };
 
@@ -594,7 +602,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   </button>
                   <button
                     onClick={() => handleToggle(rule.id, rule.enabled)}
-                    disabled={togglingId === rule.id}
+                    disabled={togglingIds.has(rule.id)}
                     aria-label={`${rule.enabled ? 'Pause' : 'Enable'} rule ${rule.name}`}
                     className={`inline-flex items-center justify-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-40 ${
                       rule.enabled
@@ -602,7 +610,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                         : 'border-accent-teal/20 text-accent-teal hover:border-accent-teal/40 hover:bg-accent-teal/5 focus-visible:ring-accent-teal/50'
                     }`}
                   >
-                    {togglingId === rule.id && (
+                    {togglingIds.has(rule.id) && (
                       <svg
                         className="h-3 w-3 animate-spin"
                         xmlns="http://www.w3.org/2000/svg"
@@ -614,7 +622,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
                     )}
-                    {togglingId === rule.id ? 'Loading…' : rule.enabled ? 'Pause' : 'Enable'}
+                    {togglingIds.has(rule.id) ? 'Loading…' : rule.enabled ? 'Pause' : 'Enable'}
                   </button>
                   <button
                     onClick={() => handleDelete(rule.id)}

--- a/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
+++ b/apps/web/app/groups/[group_id]/reactions/ReactionsEditor.tsx
@@ -79,7 +79,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [saving, setSaving] = useState(false);
-  const [toggling, setToggling] = useState(false);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -146,7 +146,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
   const handleToggle = async (id: string, current: boolean) => {
     const previousRules = rules;
     setRules((prev) => prev.map((r) => (r.id === id ? { ...r, enabled: !current } : r)));
-    setToggling(true);
+    setTogglingId(id);
     try {
       await toggleRule(groupId, id, !current);
     } catch (err) {
@@ -154,7 +154,7 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError(`Failed to toggle rule: ${message}`);
     } finally {
-      setToggling(false);
+      setTogglingId(null);
     }
   };
 
@@ -594,15 +594,27 @@ export default function ReactionsEditor({ groupId, groupName }: Props) {
                   </button>
                   <button
                     onClick={() => handleToggle(rule.id, rule.enabled)}
-                    disabled={toggling}
+                    disabled={togglingId === rule.id}
                     aria-label={`${rule.enabled ? 'Pause' : 'Enable'} rule ${rule.name}`}
-                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-40 ${
+                    className={`inline-flex items-center justify-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-40 ${
                       rule.enabled
                         ? 'border-muted/20 text-muted hover:border-muted/40 hover:text-text focus-visible:ring-muted/50'
                         : 'border-accent-teal/20 text-accent-teal hover:border-accent-teal/40 hover:bg-accent-teal/5 focus-visible:ring-accent-teal/50'
                     }`}
                   >
-                    {toggling ? 'Loading…' : rule.enabled ? 'Pause' : 'Enable'}
+                    {togglingId === rule.id && (
+                      <svg
+                        className="h-3 w-3 animate-spin"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                    )}
+                    {togglingId === rule.id ? 'Loading…' : rule.enabled ? 'Pause' : 'Enable'}
                   </button>
                   <button
                     onClick={() => handleDelete(rule.id)}


### PR DESCRIPTION
💡 What: Changed the `toggling` state from a boolean to a `string | null` in `ReactionsEditor.tsx`.
🎯 Why: Previously, when toggling a rule, a single `toggling` boolean disabled *all* toggle buttons in the list. By tracking the specific ID of the rule being toggled, only that specific button shows the loading spinner and gets disabled, preventing the rest of the list from feeling "locked up".
♿ Accessibility: Ensures that only the button actively being modified is disabled (`aria-disabled` implicitly handled by native `disabled`), preventing confusion for screen readers or keyboard navigation that might have otherwise seen the entire list suddenly become inaccessible.

---
*PR created automatically by Jules for task [16174002200061678044](https://jules.google.com/task/16174002200061678044) started by @FriskyDevelopments*