### PR TITLE
🎨 Palette: Add role and ARIA hidden to AssetPreview placeholders

### DIFF
--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,11 +23,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2" role="img" aria-label="Preview pending">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
-        <span className="text-[10px] uppercase tracking-wide text-muted/50">Preview pending</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/50" aria-hidden="true">Preview pending</span>
       </div>
     );
   }
@@ -36,10 +36,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
     return (
       <div
         className="flex h-full w-full flex-col items-center justify-center gap-1"
+        role="img"
         aria-label="Preview unavailable"
       >
         <span className="text-base text-muted/40" aria-hidden="true">—</span>
-        <span className="text-[10px] uppercase tracking-wide text-muted/40">Unavailable</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/40" aria-hidden="true">Unavailable</span>
       </div>
     );
   }


### PR DESCRIPTION
💡 **What:** Added `role="img"` to the placeholder `div` containers in `AssetPreview` for both `pending` and `failed` states. Added `aria-hidden="true"` to the internal visible text spans to prevent redundant screen reader announcements.

🎯 **Why:** Previously, the placeholder elements were generic `div` containers with an `aria-label`. Screen readers often ignore `aria-label` on elements without a semantic role. Adding `role="img"` accurately describes the element's purpose to assistive technologies. Additionally, without `aria-hidden="true"` on the internal text, screen readers might announce the label and the text content redundantly.

📸 **Before/After:** No visual changes. A Playwright script was used to verify that the placeholders still render identically on the frontend.

♿ **Accessibility:**
- Ensures placeholder elements are announced as images.
- Prevents redundant announcements of internal text spans.

---
*PR created automatically by Jules for task [6530859165615261399](https://jules.google.com/task/6530859165615261399) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for asset previews while they are loading or unavailable.
  * Added descriptive labels for pending and failed preview states without changing visual behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->