### PR TITLE
🎨 Palette: Enhance accessibility of AssetPreview placeholders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,8 @@
 ## 2024-07-16 - Screen Reader Context for Status Badges
 **Learning:** Floating status badges (e.g., "soon", "Featured", "In progress") can be confusing to screen reader users without context. For instance, just hearing "soon" or "Featured" without knowing it represents a status can be disorienting.
 **Action:** When creating status badges or similar indicators, always prefix the text with a visually hidden context string using `<span className="sr-only">Status: </span>` to ensure screen readers provide the correct meaning.
+## 2024-11-20 - AssetPreview Component Role Assignment
+
+**Learning:** When using custom \`div\` elements as visual fallbacks for images (like the pending and unavailable states in \`AssetPreview\`), simply adding \`aria-label\` is insufficient. Screen readers may announce the label but fail to convey the structural meaning (that it acts as an image). Furthermore, visible text nodes inside these placeholders cause redundant announcements.
+
+**Action:** Always add \`role="img"\` to custom \`div\` wrappers acting as images, and apply \`aria-hidden="true"\` to any internal decorative text spans to ensure a concise and accurate screen reader experience.

--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,11 +23,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2" role="img" aria-label="Preview pending">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
-        <span className="text-[10px] uppercase tracking-wide text-muted/50">Preview pending</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/50" aria-hidden="true">Preview pending</span>
       </div>
     );
   }
@@ -36,10 +36,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
     return (
       <div
         className="flex h-full w-full flex-col items-center justify-center gap-1"
+        role="img"
         aria-label="Preview unavailable"
       >
         <span className="text-base text-muted/40" aria-hidden="true">—</span>
-        <span className="text-[10px] uppercase tracking-wide text-muted/40">Unavailable</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/40" aria-hidden="true">Unavailable</span>
       </div>
     );
   }


### PR DESCRIPTION
💡 **What:** Added `role="img"` and `aria-hidden="true"` attributes to the placeholder states inside the `AssetPreview` component.
🎯 **Why:** Custom `div` placeholders meant to act as image fallbacks were not being announced as images by screen readers. Furthermore, screen readers would redundantly announce both the wrapper's `aria-label` and the internal visible text. This small fix creates a cleaner, more accurate auditory experience.
♿ **Accessibility:** Fixes redundant screen reader announcements and provides proper semantic roles for visual fallbacks.

---
*PR created automatically by Jules for task [17252923888714428606](https://jules.google.com/task/17252923888714428606) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader announcements for asset previews.
  * Added clear labels for pending and unavailable preview states.
  * Prevented decorative symbols and text from being announced redundantly.
* **Documentation**
  * Added accessibility guidance for image fallback presentations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->