### PR TITLE
🎨 Palette: Improve accessibility for non-image placeholders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,6 @@
 ## 2024-07-16 - Screen Reader Context for Status Badges
 **Learning:** Floating status badges (e.g., "soon", "Featured", "In progress") can be confusing to screen reader users without context. For instance, just hearing "soon" or "Featured" without knowing it represents a status can be disorienting.
 **Action:** When creating status badges or similar indicators, always prefix the text with a visually hidden context string using `<span className="sr-only">Status: </span>` to ensure screen readers provide the correct meaning.
+## 2024-07-29 - Improve Accessibility for Visual Placeholders
+**Learning:** When using non-image HTML elements (like `div`) as visual placeholders or fallbacks for images, they need explicit ARIA roles to be correctly interpreted by screen readers. Furthermore, any internal visible text used for styling or supplementary visual info can create redundant announcements if the container already has an `aria-label`.
+**Action:** Always add `role="img"` to the container element alongside a descriptive `aria-label`. Apply `aria-hidden="true"` to any internal visible text spans to prevent redundant announcements and ensure a clean screen reader experience.

--- a/packages/ui/src/components/AssetPreview.tsx
+++ b/packages/ui/src/components/AssetPreview.tsx
@@ -23,11 +23,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
 
   if (state === 'pending') {
     return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-2" aria-label="Preview pending">
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2" role="img" aria-label="Preview pending">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent-primary/20">
           <span className="text-lg text-accent-primary/60" aria-hidden="true">✦</span>
         </div>
-        <span className="text-[10px] uppercase tracking-wide text-muted/50">Preview pending</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/50" aria-hidden="true">Preview pending</span>
       </div>
     );
   }
@@ -36,10 +36,11 @@ export const AssetPreview = ({ url, alt, imageClassName }: AssetPreviewProps) =>
     return (
       <div
         className="flex h-full w-full flex-col items-center justify-center gap-1"
+        role="img"
         aria-label="Preview unavailable"
       >
         <span className="text-base text-muted/40" aria-hidden="true">—</span>
-        <span className="text-[10px] uppercase tracking-wide text-muted/40">Unavailable</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted/40" aria-hidden="true">Unavailable</span>
       </div>
     );
   }


### PR DESCRIPTION
💡 What: Added `role="img"` to the visual placeholder containers in `AssetPreview.tsx` and hid their internal visible text from screen readers using `aria-hidden="true"`. Documented this pattern in `.Jules/palette.md`.

🎯 Why: When using a `div` as a placeholder for an image, screen readers need an explicit role to understand its purpose. The internal text (like "Preview pending") is visually helpful but redundant for screen readers when the container already has a descriptive `aria-label`.

📸 Before/After:
Before, screen readers would announce the container's label and then redundantly read the internal text spans.
After, screen readers announce the element as an image with its descriptive label, and ignore the redundant internal text.

♿ Accessibility:
- Added explicit `role="img"` to non-image fallbacks.
- Prevented redundant screen reader announcements by applying `aria-hidden="true"` to visual-only child elements.

---
*PR created automatically by Jules for task [13066858773316631137](https://jules.google.com/task/13066858773316631137) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen reader announcements for pending and unavailable asset previews.
  * Added descriptive semantics to visual placeholder states while preventing redundant text from being read aloud.

* **Documentation**
  * Added guidance for making non-image visual placeholders more accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->