### PR TITLE
🎨 Palette: Improve GeneratorScaffold semantic stepper accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,7 +67,3 @@
 ## 2024-07-29 - Improve Accessibility for Visual Placeholders
 **Learning:** When using non-image HTML elements (like `div`) as visual placeholders or fallbacks for images, they need explicit ARIA roles to be correctly interpreted by screen readers. Furthermore, any internal visible text used for styling or supplementary visual info can create redundant announcements if the container already has an `aria-label`.
 **Action:** Always add `role="img"` to the container element alongside a descriptive `aria-label`. Apply `aria-hidden="true"` to any internal visible text spans to prevent redundant announcements and ensure a clean screen reader experience.
-
-## 2024-12-16 - Semantic Stepper Navigation
-**Learning:** Stepper components (like the generator scaffold) built with a simple list of buttons in a generic `<div>` container lack structural context for screen readers. Users navigating sequentially won't hear how many steps there are in total or which step they are currently on beyond just reading the visual number out of context.
-**Action:** Always structure stepper components using ordered lists (`<ol aria-label="Steps">` with `<li>` items). Explicitly hide purely visual step numbers with `aria-hidden="true"` and replace them with visually hidden screen reader text (e.g., `<span className="sr-only">Step 1: </span>`) to provide proper context and grouping.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -67,3 +67,7 @@
 ## 2024-07-29 - Improve Accessibility for Visual Placeholders
 **Learning:** When using non-image HTML elements (like `div`) as visual placeholders or fallbacks for images, they need explicit ARIA roles to be correctly interpreted by screen readers. Furthermore, any internal visible text used for styling or supplementary visual info can create redundant announcements if the container already has an `aria-label`.
 **Action:** Always add `role="img"` to the container element alongside a descriptive `aria-label`. Apply `aria-hidden="true"` to any internal visible text spans to prevent redundant announcements and ensure a clean screen reader experience.
+
+## 2024-12-16 - Semantic Stepper Navigation
+**Learning:** Stepper components (like the generator scaffold) built with a simple list of buttons in a generic `<div>` container lack structural context for screen readers. Users navigating sequentially won't hear how many steps there are in total or which step they are currently on beyond just reading the visual number out of context.
+**Action:** Always structure stepper components using ordered lists (`<ol aria-label="Steps">` with `<li>` items). Explicitly hide purely visual step numbers with `aria-hidden="true"` and replace them with visually hidden screen reader text (e.g., `<span className="sr-only">Step 1: </span>`) to provide proper context and grouping.

--- a/packages/ui/src/components/GeneratorScaffold.tsx
+++ b/packages/ui/src/components/GeneratorScaffold.tsx
@@ -19,37 +19,35 @@ export const GeneratorScaffold = ({ steps }: GeneratorScaffoldProps) => {
 
   return (
     <div className="rounded-2xl border border-white/10 bg-panel p-6">
-      <ol className="flex flex-wrap gap-2" aria-label="Generator Steps">
+      <div className="flex flex-wrap gap-2">
         {steps.map((step, index) => (
-          <li key={step.id}>
-            <button
-              onClick={() => !step.comingSoon && setActiveStep(step.id)}
-              aria-disabled={step.comingSoon}
-              aria-current={step.id === activeStep ? 'step' : undefined}
-              className={cn(
-                'flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
-                step.id === activeStep
-                  ? 'border-accent-primary bg-accent-primary/10 text-text'
-                  : step.comingSoon
-                    ? 'cursor-not-allowed border-white/5 bg-panel-secondary text-muted/50'
-                    : 'border-white/10 bg-panel-secondary text-muted hover:border-white/30 hover:text-text'
-              )}
-            >
-              <span className="sr-only">Step {index + 1}: </span>
-              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-background text-xs text-accent-cyan" aria-hidden="true">
-                {index + 1}
+          <button
+            key={step.id}
+            onClick={() => !step.comingSoon && setActiveStep(step.id)}
+            aria-disabled={step.comingSoon}
+            aria-current={step.id === activeStep ? 'step' : undefined}
+            className={cn(
+              'flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
+              step.id === activeStep
+                ? 'border-accent-primary bg-accent-primary/10 text-text'
+                : step.comingSoon
+                  ? 'cursor-not-allowed border-white/5 bg-panel-secondary text-muted/50'
+                  : 'border-white/10 bg-panel-secondary text-muted hover:border-white/30 hover:text-text'
+            )}
+          >
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-background text-xs text-accent-cyan">
+              {index + 1}
+            </span>
+            {step.label}
+            {step.comingSoon && (
+              <span className="rounded-full bg-accent-violet/20 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-accent-violet">
+                <span className="sr-only">Status: </span>
+                soon
               </span>
-              {step.label}
-              {step.comingSoon && (
-                <span className="rounded-full bg-accent-violet/20 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-accent-violet">
-                  <span className="sr-only">Status: </span>
-                  soon
-                </span>
-              )}
-            </button>
-          </li>
+            )}
+          </button>
         ))}
-      </ol>
+      </div>
       <div className="mt-6">
         {steps.map((step) =>
           step.id === activeStep ? (

--- a/packages/ui/src/components/GeneratorScaffold.tsx
+++ b/packages/ui/src/components/GeneratorScaffold.tsx
@@ -19,35 +19,37 @@ export const GeneratorScaffold = ({ steps }: GeneratorScaffoldProps) => {
 
   return (
     <div className="rounded-2xl border border-white/10 bg-panel p-6">
-      <div className="flex flex-wrap gap-2">
+      <ol className="flex flex-wrap gap-2" aria-label="Generator Steps">
         {steps.map((step, index) => (
-          <button
-            key={step.id}
-            onClick={() => !step.comingSoon && setActiveStep(step.id)}
-            aria-disabled={step.comingSoon}
-            aria-current={step.id === activeStep ? 'step' : undefined}
-            className={cn(
-              'flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
-              step.id === activeStep
-                ? 'border-accent-primary bg-accent-primary/10 text-text'
-                : step.comingSoon
-                  ? 'cursor-not-allowed border-white/5 bg-panel-secondary text-muted/50'
-                  : 'border-white/10 bg-panel-secondary text-muted hover:border-white/30 hover:text-text'
-            )}
-          >
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-background text-xs text-accent-cyan">
-              {index + 1}
-            </span>
-            {step.label}
-            {step.comingSoon && (
-              <span className="rounded-full bg-accent-violet/20 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-accent-violet">
-                <span className="sr-only">Status: </span>
-                soon
+          <li key={step.id}>
+            <button
+              onClick={() => !step.comingSoon && setActiveStep(step.id)}
+              aria-disabled={step.comingSoon}
+              aria-current={step.id === activeStep ? 'step' : undefined}
+              className={cn(
+                'flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50',
+                step.id === activeStep
+                  ? 'border-accent-primary bg-accent-primary/10 text-text'
+                  : step.comingSoon
+                    ? 'cursor-not-allowed border-white/5 bg-panel-secondary text-muted/50'
+                    : 'border-white/10 bg-panel-secondary text-muted hover:border-white/30 hover:text-text'
+              )}
+            >
+              <span className="sr-only">Step {index + 1}: </span>
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-background text-xs text-accent-cyan" aria-hidden="true">
+                {index + 1}
               </span>
-            )}
-          </button>
+              {step.label}
+              {step.comingSoon && (
+                <span className="rounded-full bg-accent-violet/20 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-accent-violet">
+                  <span className="sr-only">Status: </span>
+                  soon
+                </span>
+              )}
+            </button>
+          </li>
         ))}
-      </div>
+      </ol>
       <div className="mt-6">
         {steps.map((step) =>
           step.id === activeStep ? (

--- a/services/api/data/jobs.json
+++ b/services/api/data/jobs.json
@@ -20,5 +20,16 @@
     "attempts": 0,
     "maxAttempts": 3,
     "runAt": "2026-04-15T02:04:21.820Z"
+  },
+  {
+    "id": "2d9c3a51-3484-4f96-b86b-847d8f8b215e",
+    "jobType": "trigger.execute",
+    "payload": {
+      "messageId": 1
+    },
+    "status": "completed",
+    "attempts": 0,
+    "maxAttempts": 3,
+    "runAt": "2026-08-01T01:32:58.683Z"
   }
 ]

--- a/services/api/data/jobs.json
+++ b/services/api/data/jobs.json
@@ -20,16 +20,5 @@
     "attempts": 0,
     "maxAttempts": 3,
     "runAt": "2026-04-15T02:04:21.820Z"
-  },
-  {
-    "id": "2d9c3a51-3484-4f96-b86b-847d8f8b215e",
-    "jobType": "trigger.execute",
-    "payload": {
-      "messageId": 1
-    },
-    "status": "completed",
-    "attempts": 0,
-    "maxAttempts": 3,
-    "runAt": "2026-08-01T01:32:58.683Z"
   }
 ]


### PR DESCRIPTION
💡 **What:** The UX enhancement added semantic list structure (`<ol>`) and explicit screen reader labels (`sr-only`) to the `GeneratorScaffold` step navigation.
🎯 **Why:** Previously, the steps were just buttons in a generic flex `div`, making it impossible for screen reader users to know they were in a sequence, how many steps there were, or which step number they were on (since the visual number was read without context).
📸 **Before/After:** The visual layout is identical (thanks to Tailwind resetting list styles), but the DOM structure is now fully semantic.
♿ **Accessibility:** Screen readers now announce the group as a list (e.g., "List, 3 items"), and each step explicitly announces its position (e.g., "Step 1: Feed your image").

---
*PR created automatically by Jules for task [4110968841759616475](https://jules.google.com/task/4110968841759616475) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved step navigation semantics for screen readers.
  * Added clearer step labels and context while preserving existing active, disabled, and upcoming-step behavior.

* **Documentation**
  * Added guidance for accessible stepper navigation, including ordered lists and visually hidden step numbers.

* **Data Updates**
  * Added a completed job record to the available job data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->